### PR TITLE
feat: add poster MR2S variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ results/face_k_analysis/optimal_k_evidence.json
 .idea
 .cache
 venv
+
+.DS_store

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ python main.py poster-results \
 
 | 옵션 | 기본값 | 설명 |
 |---|---|---|
-| `--sizes` | 5 10 20 30 | 실험할 그래프 정점 수 목록 |
+| `--sizes` | 100 200 300 400 500 | 실험할 그래프 정점 수 목록 |
 | `--num-graphs` | 5 | size별 독립 그래프 생성 수 |
-| `--seed` | None | 재현성을 위한 기본 랜덤 시드 |
+| `--seed` | 42 | 재현성을 위한 기본 랜덤 시드 |
 | `--output-dir` | `results/poster` | 결과 JSON·플롯·cache 저장 디렉토리 |
 | `--num-workers` | CPU 기반 자동값 | trial 병렬 실행 process 수. 0이면 순차 실행 |
 | `--cache-dir` | `<output-dir>/poster_trial_cache` | trial cache 디렉토리 |

--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ Analysing the n-hop approach on random directed graphs.
 | `src/graph_generator.py` | 정점 수와 연결성 확률로 무방향 랜덤 그래프 생성 |
 | `src/case_generator.py` | 전수 열거(`generate_strongly_connected_orientations`) 및 무작위 샘플링(`sample_strongly_connected_orientations`) 기반으로 강연결(strongly-connected) 방향 그래프 산출 |
 | `src/score_calculator.py` | NumPy 기반 APSP 합계 및 n-hop 이웃 수(n=2,3,4) 계산 |
-| `src/visualizer.py` | APSP 점수 간 상관관계 산점도, n-hop 수 / 연결성 비교 그래프, face-k 분석 시각화 |
+| `src/visualizer.py` | APSP 점수 간 상관관계 산점도, n-hop 수 / 연결성 비교 그래프, face-k 및 poster 결과 시각화 |
 | `src/commands/face_k_analysis.py` | `mr2s-module`의 `FaceCycle`을 활용한 최적 face-cycle target k 분석 |
+| `src/commands/poster_results.py` | MR2S poster용 solver 비교 실험 실행 |
+| `src/commands/poster_results_solvers.py` | Raw SA, Global QUBO, DnC MR2S, random baseline trial 실행 |
+| `src/commands/poster_results_partition_strategy.py` | DnC partition strategy별 실행 및 진단 |
+| `src/commands/poster_results_runner.py` | poster-results 집계, cache 재사용, 병렬 실행 |
 
 ## 설치 (Installation)
 
@@ -20,7 +24,7 @@ pip install -r requirements.txt
 
 ## 사용법 (Usage)
 
-`main.py`는 두 개의 서브 커맨드를 제공합니다.
+`main.py`는 `analyse`, `nhop-connectivity`, `face-k-analysis`, `poster-results` 서브 커맨드를 제공합니다.
 
 ### `analyse` – 단일 그래프의 APSP·n-hop 상관관계 분석
 
@@ -128,6 +132,67 @@ python main.py face-k-analysis \
 - `face_k_analysis.png` – SC 비율 / APSP 추이 2×2 그래프
 - `report.md` – 실험 요약 및 경험적 최적 k 공식 보고서
 
+---
+
+### `poster-results` – MR2S poster solver 비교
+
+Raw SA, Global QUBO, MR2S 변형 solver, DnC MR2S, random baseline을 같은 Delaunay 그래프에서 비교합니다.
+DnC MR2S는 `mr2s-module==0.0.8`의 `graph_partition_strategy` hook을 사용하며,
+현재 결과에는 다음 MR2S 변형과 DnC partition strategy가 같은 solver 비교 그래프 안에 함께 표시됩니다.
+
+| MR2S variant | 설명 |
+|---|---|
+| `robbin_mr2s` | `Robbin` edge orienter로 초기 방향을 만든 뒤 MR2S QUBO solver 실행 |
+| `iterated_local_search_mr2s` | `IteratedLocalSearch` edge orienter로 초기 방향을 만든 뒤 MR2S QUBO solver 실행 |
+
+| DnC strategy | 설명 |
+|---|---|
+| `poster` | poster 실험용 embedding 진단과 target_k 이진 탐색 strategy |
+| `embedding_aware` | `mr2s-module`의 `EmbeddingAwareFaceCyclePartitionStrategy` |
+| `degeneracy_pruning` | `mr2s-module`의 `DegeneracyPruningFaceCyclePartitionStrategy` |
+
+```bash
+# 현재 poster 결과 재현: size 5, 10, 20 / size당 5개 graph
+python main.py poster-results \
+    --sizes 5 10 20 \
+    --output-dir results/poster \
+    --no-cache
+
+# cache를 사용해 누락된 size만 계산하고 기존 poster_results.json과 병합
+python main.py poster-results --sizes 5 10 20 --output-dir results/poster
+
+# 기존 결과의 MR2S/DnC 결과만 다시 계산해 병합
+python main.py poster-results \
+    --sizes 5 10 20 \
+    --output-dir results/poster \
+    --mr2s-only
+```
+
+#### `poster-results` CLI 옵션
+
+| 옵션 | 기본값 | 설명 |
+|---|---|---|
+| `--sizes` | 5 10 20 30 | 실험할 그래프 정점 수 목록 |
+| `--num-graphs` | 5 | size별 독립 그래프 생성 수 |
+| `--seed` | None | 재현성을 위한 기본 랜덤 시드 |
+| `--output-dir` | `results/poster` | 결과 JSON·플롯·cache 저장 디렉토리 |
+| `--num-workers` | CPU 기반 자동값 | trial 병렬 실행 process 수. 0이면 순차 실행 |
+| `--cache-dir` | `<output-dir>/poster_trial_cache` | trial cache 디렉토리 |
+| `--no-cache` | False | trial cache 읽기/쓰기를 끄고 재계산 |
+| `--mr2s-only` | False | 기존 결과를 유지하고 MR2S/DnC 결과만 다시 계산 |
+| `--source-results` | `<output-dir>/poster_results.json` | `--mr2s-only` 병합 기준 결과 파일 |
+
+poster 결과의 기본 저장 경로는 `results/poster/poster_results.json`이며, 위 재현 명령은 size 축 `[5, 10, 20]`을 사용합니다.
+`spent_time.png`는 embed/probe 시간을 제외한 solve time만 solver 라인으로 표시합니다.
+embed timing은 plot에는 넣지 않지만 JSON의 `timings` 섹션에는 보존합니다.
+
+결과 파일:
+- `poster_results.json` – solver별 평균 점수, MR2S 변형, DnC strategy별 결과, timing, partition 진단
+- `apsp_reduction.png` – Random / Raw SA / Global / MR2S 변형 / DnC strategy별 normalized APSP 비교
+- `flow_stability.png` – Random / Raw SA / Global / MR2S 변형 / DnC strategy별 flow imbalance 비교
+- `scalability.png` – Global QUBO와 DnC strategy별 QUBO 변수·subgraph·physical qubit 비교
+- `spent_time.png` – graph generation, Raw SA, Global solve, MR2S 변형, DnC strategy별 solve time, random baseline 비교
+
 ## 테스트 (Tests)
 
 ```bash
@@ -138,7 +203,7 @@ python -m pytest tests/ -v
 
 ```
 n-hop-approach-analysis/
-├── main.py               # 실행 진입점 (analyse / nhop-connectivity / face-k-analysis 서브 커맨드)
+├── main.py               # 실행 진입점 (analyse / nhop-connectivity / face-k-analysis / poster-results)
 ├── requirements.txt
 ├── src/
 │   ├── graph_generator.py
@@ -148,18 +213,30 @@ n-hop-approach-analysis/
 │   └── commands/
 │       ├── analyse.py
 │       ├── nhop_connectivity.py
-│       └── face_k_analysis.py
+│       ├── face_k_analysis.py
+│       ├── poster_results.py
+│       ├── poster_results_models.py
+│       ├── poster_results_plotting.py
+│       ├── poster_results_runner.py
+│       ├── poster_results_solvers.py
+│       └── poster_results_partition_strategy.py
 ├── results/
-│   └── face_k_analysis/
+│   ├── face_k_analysis/
 │       ├── face_k_results.json
 │       ├── face_k_analysis.png
 │       └── report.md
+│   └── poster/
+│       ├── poster_results.json
+│       ├── apsp_reduction.png
+│       ├── flow_stability.png
+│       ├── scalability.png
+│       └── spent_time.png
 └── tests/
     ├── test_graph_generator.py
     ├── test_case_generator.py
     ├── test_score_calculator.py
     ├── test_visualizer.py
     ├── test_nhop_connectivity_cmd.py
-    └── test_face_k_analysis_cmd.py
+    ├── test_face_k_analysis_cmd.py
+    └── test_poster_results_cmd.py
 ```
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ matplotlib>=3.6
 numpy>=1.24
 scipy>=1.10
 pytest>=7.0
-mr2s-module==0.0.5
+mr2s-module==0.0.8

--- a/src/commands/face_k_analysis.py
+++ b/src/commands/face_k_analysis.py
@@ -37,9 +37,9 @@ import networkx as nx
 import numpy as np
 from scipy.spatial import Delaunay
 
-from mr2s_module import FaceCycle, Graph as MR2SGraph, Edge as MR2SEdge, NHop, \
-  QuboMR2SSolver, SAQuboSolver, ApspSumRanker, Evaluator, NHopPolyGenerator, \
-  FlowPolyGenerator, SmallWorldSpec
+from mr2s_module import FaceClusterPartition as FaceCycle, Graph as MR2SGraph, \
+  Edge as MR2SEdge, NHop, QuboMR2SSolver, SAQuboSolver, ApspSumRanker, \
+  Evaluator, NHopPolyGenerator, FlowPolyGenerator, SmallWorldSpec
 
 from src.visualizer import plot_face_k_analysis, plot_optimal_k_fit_evidence
 

--- a/src/commands/poster_results.py
+++ b/src/commands/poster_results.py
@@ -1,161 +1,89 @@
-"""``poster-results`` subcommand – MR2S poster visualization data generation.
-
-Four categories:
-1. Raw SA (SAMR2SSolver)
-2. Global (QuboMR2SSolver)
-3. Clustered (DnCMr2sSolver)
-4. Random baseline
-"""
+"""``poster-results`` subcommand - MR2S poster visualization data generation."""
 
 from __future__ import annotations
 
 import argparse
-import concurrent.futures
-import json
-import multiprocessing
-import os
-import time
 from typing import Any
 
-import numpy as np
-import mr2s_module.domain.graph
+import networkx as nx
 
-# Patch missing is_empty method in mr2s_module.domain.graph.Graph class directly
-if not hasattr(mr2s_module.domain.graph.Graph, 'is_empty'):
-    def is_empty(self):
-        return len(self.edges) == 0
-    mr2s_module.domain.graph.Graph.is_empty = is_empty
-
-from mr2s_module import SAMR2SSolver, Evaluator, estimate_required_qubits, \
-  QuboMR2SSolver, SAQuboSolver, ApspSumRanker, NHopPolyGenerator, \
-  FlowPolyGenerator, SmallWorldSpec, NHop
-from mr2s_module.solver.dnc_mr2s_solver import DnCMr2sSolver
-
-from src.commands.face_k_analysis import _generate_delaunay_graph, _nx_to_mr2s_graph
-from src.case_generator import sample_strongly_connected_orientations
-from src.cache import SimpleCache, generate_cache_key
+from src.cache import generate_cache_key
+from src.commands.poster_results_cache import cached_trial_result
+from src.commands.poster_results_models import (
+    Mr2sTrialResult,
+    PosterTrialResult,
+)
+from src.commands.poster_results_plotting import _plot_results
+from src.commands.poster_results_runner import (
+    Mr2sOnlyPosterResultsRunner,
+    PosterResultsAggregator,
+    PosterResultsRunner,
+    PosterRunConfig,
+    TrialScheduler,
+)
+from src.commands import poster_results_solvers as _solver_helpers
+from src.commands.poster_results_solvers import (
+    _mean_finite,
+    _normalize_random_baseline,
+    _run_mr2s_trial,
+    _run_trial,
+)
 from src.score_calculator import calculate_apsp_sum_and_nhop_neighbor_counts
-from src.visualizer import plot_apsp_reduction, plot_flow_stability, plot_preprocessing_scalability
 
-spec = SmallWorldSpec([NHop(2, 1), NHop(3, 1)])
-POSTER_CACHE_VERSION = 2
-
+POSTER_CACHE_VERSION = 5
 TrialTask = tuple[int, int, int | None, str | None]
 
-def _as_finite_or_nan(value: Any) -> float:
-    value = float(value)
-    return value if np.isfinite(value) else float("nan")
 
-def _mean_finite(values: list[float]) -> float:
-    finite_values = [_as_finite_or_nan(value) for value in values]
-    finite_values = [value for value in finite_values if np.isfinite(value)]
-    if not finite_values:
-        return float("nan")
-    return float(np.mean(finite_values))
+# 테스트와 기존 내부 호출자가 이 모듈의 private helper를 직접 monkeypatch하므로
+# solver 모듈로 위임하는 얇은 호환 래퍼를 유지한다.
+def _sample_random_orientations(
+    graph: nx.Graph,
+    max_samples: int,
+    seed: int | None = None,
+) -> list[nx.DiGraph]:
+    return _solver_helpers._sample_random_orientations(graph, max_samples, seed)
 
-def _normalize_random_baseline(result: dict[str, Any]) -> dict[str, Any]:
-    """Treat missing random samples as unavailable, not as a zero score."""
-    sample_count = result.get("sample_count")
-    missing_legacy_sample = sample_count is None and result.get("apsp") == 0 and result.get("flow") == 0
-    if sample_count == 0 or missing_legacy_sample:
-        normalized = dict(result)
-        normalized["apsp"] = float("nan")
-        normalized["flow"] = float("nan")
-        normalized["sample_count"] = 0
-        return normalized
-    return result
 
-def _build_sa_solver(seed: int | None = None) -> SAMR2SSolver:
-    return SAMR2SSolver(
-        evaluator=Evaluator(),
-        random_seed=seed
-    )
+def _flow_imbalance_score(graph: nx.DiGraph) -> int:
+    return _solver_helpers._flow_imbalance_score(graph)
 
-def _build_qubo_solver() -> QuboMR2SSolver:
-    n_hop_poly = NHopPolyGenerator()
-    n_hop_poly.small_world_spec = spec
-    return QuboMR2SSolver(
-        qubo_solver=SAQuboSolver(ApspSumRanker()),
-        evaluator=Evaluator(),
-        poly_generators=[n_hop_poly, FlowPolyGenerator()],
-    )
 
-def _build_dnc_qubo_solver() -> DnCMr2sSolver:
-    return DnCMr2sSolver(
-      mr2s_solver=_build_qubo_solver()
-    )
+def _calculate_random_baseline(
+    graph: nx.Graph,
+    n: int,
+    seed: int | None,
+    max_samples: int = 10,
+) -> dict[str, Any]:
+    random_samples = _sample_random_orientations(graph, max_samples=max_samples, seed=seed)
+    trial_apsp = []
+    trial_flow = []
 
-def _estimate_physical_qubits_with_status(bqm: Any) -> tuple[float, bool, str | None]:
-    try:
-        return float(estimate_required_qubits(bqm).num_physical_qubits), True, None
-    except RuntimeError as exc:
-        return float("nan"), False, str(exc)
+    for orient in random_samples:
+        # APSP는 강연결 방향 그래프에서만 의미 있게 비교하고,
+        # flow imbalance는 강연결 여부와 무관하게 모든 샘플의 기준값으로 남긴다.
+        if nx.is_strongly_connected(orient):
+            apsp, _ = calculate_apsp_sum_and_nhop_neighbor_counts(orient, hops=[])
+            trial_apsp.append(apsp / (n * (n - 1)))
+        trial_flow.append(_flow_imbalance_score(orient))
 
-def _estimate_physical_qubits(bqm: Any) -> float:
-    """Return physical qubits for embeddable BQMs; NaN when embedding fails."""
-    physical_qubits, _, _ = _estimate_physical_qubits_with_status(bqm)
-    return physical_qubits
-
-def _probe_embedding(mr2s_solver: QuboMR2SSolver, graph: Any) -> dict[str, Any]:
-    bqm = mr2s_solver.build_bqm(graph)
-    physical_qubits, can_embed, error = _estimate_physical_qubits_with_status(bqm)
     return {
-        "can_embed": can_embed,
-        "qvars": len(bqm.variables),
-        "physical_qubits": physical_qubits,
-        "error": error,
+        "apsp": _mean_finite(trial_apsp),
+        "flow": _mean_finite(trial_flow),
+        "sample_count": len(random_samples),
+        "strong_sample_count": len(trial_apsp),
     }
 
-def _can_recurse_partition(parent: Any, sub_graphs: list[Any]) -> bool:
-    if not sub_graphs:
-        return False
 
-    parent_edge_count = len(parent.edges)
-    return all(
-        0 < len(sub_graph.edges) < parent_edge_count
-        for sub_graph in sub_graphs
-    )
+def _probe_embedding(mr2s_solver: Any, graph: Any) -> dict[str, Any]:
+    return _solver_helpers._probe_embedding(mr2s_solver, graph)
+
 
 def _partition_with_target_k(face_cycle: Any, graph: Any, target_k: int) -> Any:
-    previous_target_k = face_cycle.target_k
-    face_cycle.target_k = target_k
-    try:
-        return face_cycle.run(graph)
-    finally:
-        face_cycle.target_k = previous_target_k
+    return _solver_helpers._partition_with_target_k(face_cycle, graph, target_k)
 
-def _summarize_partition_attempt(
-    target_k: int,
-    result: Any,
-    can_recurse: bool,
-    probes: list[dict[str, Any]],
-    accepted: bool,
-) -> dict[str, Any]:
-    sub_graphs = result.sub_graphs
-    finite_physical = [
-        probe["physical_qubits"]
-        for probe in probes
-        if np.isfinite(probe["physical_qubits"])
-    ]
-    qvars = [probe["qvars"] for probe in probes]
-    return {
-        "target_k": target_k,
-        "subgraph_count": len(sub_graphs),
-        "remaining_edge_count": len(result.remaining_edges),
-        "edge_counts": [len(sub_graph.edges) for sub_graph in sub_graphs],
-        "can_recurse": can_recurse,
-        "all_embed": bool(probes) and all(probe["can_embed"] for probe in probes),
-        "accepted": accepted,
-        "embed_failures": sum(not probe["can_embed"] for probe in probes),
-        "qvars": qvars,
-        "max_qvars": max(qvars) if qvars else 0,
-        "total_qvars": sum(qvars),
-        "physical_qubits": [probe["physical_qubits"] for probe in probes],
-        "physical_total": float(sum(finite_physical)) if finite_physical else float("nan"),
-    }
 
 def _find_partition_by_target_k_with_diagnostics(
-    mr2s_solver: QuboMR2SSolver,
+    mr2s_solver: Any,
     face_cycle: Any,
     graph: Any,
 ) -> tuple[list[Any], dict[str, Any]]:
@@ -166,10 +94,12 @@ def _find_partition_by_target_k_with_diagnostics(
     attempts: list[dict[str, Any]] = []
 
     while left <= right:
+        # target_k가 작을수록 큰 subgraph가 생길 수 있으므로,
+        # embedding 가능한 가장 작은 target_k를 이진 탐색한다.
         target_k = (left + right) // 2
         result = _partition_with_target_k(face_cycle, graph, target_k)
         sub_graphs = result.sub_graphs
-        can_recurse = _can_recurse_partition(graph, sub_graphs)
+        can_recurse = _solver_helpers._can_recurse_partition(graph, sub_graphs)
         probes = (
             [_probe_embedding(mr2s_solver, sub_graph) for sub_graph in sub_graphs]
             if can_recurse
@@ -177,7 +107,7 @@ def _find_partition_by_target_k_with_diagnostics(
         )
         accepted = can_recurse and all(probe["can_embed"] for probe in probes)
         attempts.append(
-            _summarize_partition_attempt(
+            _solver_helpers._summarize_partition_attempt(
                 target_k=target_k,
                 result=result,
                 can_recurse=can_recurse,
@@ -200,7 +130,9 @@ def _find_partition_by_target_k_with_diagnostics(
     }
     return best_sub_graphs or [], diagnostics
 
-def _divide_graph_with_diagnostics(solver: DnCMr2sSolver, graph: Any) -> tuple[list[Any], dict[str, Any]]:
+
+def _divide_graph_with_diagnostics(solver: Any, graph: Any) -> tuple[list[Any], dict[str, Any]]:
+    # 전체 그래프가 바로 embedding 가능하면 분할하지 않는다.
     whole_graph_probe = _probe_embedding(solver.mr2s_solver, graph)
     diagnostics = {
         "whole_graph": whole_graph_probe,
@@ -218,163 +150,12 @@ def _divide_graph_with_diagnostics(solver: DnCMr2sSolver, graph: Any) -> tuple[l
     )
     diagnostics.update(partition_diagnostics)
     if not sub_graphs:
+        # 분할도 실패하면 기존 solver 동작을 유지하기 위해 전체 그래프로 fallback한다.
         diagnostics["selected_reason"] = "fallback_whole_graph"
         diagnostics["selected_probes"] = [whole_graph_probe]
         return [graph], diagnostics
     return sub_graphs, diagnostics
 
-def _physical_qubit_stats(values: list[float]) -> dict[str, float]:
-    finite_values = [value for value in values if not np.isnan(value)]
-    if not finite_values:
-        return {
-            "total": float("nan"),
-            "max": float("nan"),
-            "mean": float("nan"),
-            "min": float("nan"),
-        }
-    return {
-        "total": float(sum(finite_values)),
-        "max": float(max(finite_values)),
-        "mean": float(np.mean(finite_values)),
-        "min": float(min(finite_values)),
-    }
-
-def _run_clustered_solver(graph: Any, n: int) -> tuple[dict[str, Any], dict[str, float]]:
-    timings: dict[str, float] = {}
-
-    start = time.monotonic()
-    solver_cls = _build_dnc_qubo_solver()
-    graph_cls = _nx_to_mr2s_graph(graph)
-    sub_graphs_cls, partition_diagnostics = _divide_graph_with_diagnostics(
-        solver_cls,
-        graph_cls,
-    )
-    if len(sub_graphs_cls) == 1 and sub_graphs_cls[0] is graph_cls:
-        sol_cls = solver_cls.mr2s_solver.run(graph_cls)
-    else:
-        sub_solutions = solver_cls._solve_subgraphs(sub_graphs_cls)
-        merged_solution = solver_cls.merge_solutions(
-            solutions=sub_solutions,
-            graph=graph_cls,
-        )
-        solver_cls._apply_merged_directions(graph_cls, merged_solution)
-        sol_cls = solver_cls.mr2s_solver.run(graph_cls)
-        sol_cls.score = solver_cls.score_merged_solution(sol_cls, sub_solutions)
-    timings["clustered_solve"] = time.monotonic() - start
-
-    start = time.monotonic()
-    selected_probes = partition_diagnostics.get("selected_probes", [])
-    cluster_phys = [
-        probe["physical_qubits"]
-        for probe in selected_probes
-        if probe["qvars"] > 0
-    ]
-    cluster_qvars = [
-        probe["qvars"]
-        for probe in selected_probes
-        if probe["qvars"] > 0
-    ]
-
-    if not cluster_qvars:
-        cluster_qvars = [0]
-    if not cluster_phys:
-        cluster_phys = [0]
-
-    timings["clustered_embed"] = time.monotonic() - start
-    phys_cls = _physical_qubit_stats(cluster_phys)
-
-    return {
-        "apsp": sol_cls.score.apsp_sum / (n * (n - 1)),
-        "flow": sol_cls.score.flow_score,
-        "qvars": sum(cluster_qvars),
-        "sg": max(cluster_qvars),
-        "phys_total": phys_cls["total"],
-        "phys_max": phys_cls["max"],
-        "phys_mean": phys_cls["mean"],
-        "phys_min": phys_cls["min"],
-        "partition": partition_diagnostics,
-    }, timings
-
-def _run_trial(task: tuple[int, int, int | None]) -> tuple[int, int, dict[str, Any]]:
-    """Run all poster-result solvers for one graph trial."""
-    n, trial, seed = task
-    trial_seed = (seed + trial * 100 + n) if seed is not None else None
-    graph = _generate_delaunay_graph(n, trial_seed)
-    timings: dict[str, float] = {}
-
-    # 1. Raw SA
-    start = time.monotonic()
-    solver_rsa = _build_sa_solver(seed=trial_seed)
-    solver_rsa.face_cycle = None
-    sol_rsa = solver_rsa.run(_nx_to_mr2s_graph(graph))
-    timings["raw_sa"] = time.monotonic() - start
-    res_rsa = {
-        "apsp": sol_rsa.score.apsp_sum / (n * (n - 1)),
-        "flow": sol_rsa.score.flow_score,
-    }
-
-    # 2. Global
-    start = time.monotonic()
-    solver_glb = _build_qubo_solver()
-    solver_glb.face_cycle = None
-    sol_glb = solver_glb.run(_nx_to_mr2s_graph(graph))
-    timings["global_solve"] = time.monotonic() - start
-
-    start = time.monotonic()
-    bqm_glb = solver_glb.build_bqm(_nx_to_mr2s_graph(graph))
-    phys_glb = _estimate_physical_qubits(bqm_glb)
-    timings["global_embed"] = time.monotonic() - start
-
-    res_glb = {
-        "apsp": sol_glb.score.apsp_sum / (n * (n - 1)),
-        "flow": sol_glb.score.flow_score,
-        "qvars": len(bqm_glb.variables),
-        "sg": len(bqm_glb.variables),
-        "pt": phys_glb,
-    }
-
-    # 3. Clustered
-    res_cls, clustered_timings = _run_clustered_solver(graph, n)
-    timings.update(clustered_timings)
-
-    # 4. Random
-    start = time.monotonic()
-    random_samples = list(
-        sample_strongly_connected_orientations(
-            graph, max_samples=10, seed=trial_seed
-        )
-    )
-    if random_samples:
-        trial_apsp = []
-        trial_flow = []
-        for orient in random_samples:
-            apsp, _ = calculate_apsp_sum_and_nhop_neighbor_counts(orient, hops=[])
-            trial_apsp.append(apsp / (n * (n - 1)))
-            imbalance = sum(
-                (orient.in_degree(node) - orient.out_degree(node)) ** 2
-                for node in orient.nodes()
-            )
-            trial_flow.append(imbalance)
-        res_rnd = {
-            "apsp": np.mean(trial_apsp),
-            "flow": np.mean(trial_flow),
-            "sample_count": len(random_samples),
-        }
-    else:
-        res_rnd = {
-            "apsp": float("nan"),
-            "flow": float("nan"),
-            "sample_count": 0,
-        }
-    timings["random"] = time.monotonic() - start
-
-    return n, trial, {
-        "raw_sa": res_rsa,
-        "global": res_glb,
-        "mr2s": res_cls,
-        "random": res_rnd,
-        "timings": timings,
-    }
 
 def _poster_trial_cache_key(n: int, trial: int, seed: int | None) -> str:
     """Return the stable cache key for one poster-result graph trial."""
@@ -386,6 +167,7 @@ def _poster_trial_cache_key(n: int, trial: int, seed: int | None) -> str:
         seed=seed,
     )
 
+
 def _poster_mr2s_trial_cache_key(n: int, trial: int, seed: int | None) -> str:
     """Return the stable cache key for one MR2S-only poster trial."""
     return generate_cache_key(
@@ -396,70 +178,54 @@ def _poster_mr2s_trial_cache_key(n: int, trial: int, seed: int | None) -> str:
         seed=seed,
     )
 
-def _run_trial_with_cache(
-    task: tuple[int, int, int | None, str | None]
-) -> tuple[int, int, dict[str, Any]]:
-    """Run one poster trial, reusing the on-disk cache when configured."""
-    n, trial, seed, cache_dir = task
-    if cache_dir is None:
-        n, trial, result = _run_trial((n, trial, seed))
-        result["cache_hit"] = False
-        result.setdefault("timings", {})["cache_hit"] = False
-        return n, trial, result
 
-    cache = SimpleCache(cache_dir)
-    cache_key = _poster_trial_cache_key(n, trial, seed)
-    cached_result = cache.get(cache_key)
-    if isinstance(cached_result, dict):
-        cached_result["cache_hit"] = True
-        cached_result.setdefault("timings", {})["cache_hit"] = True
-        return n, trial, cached_result
+def _coerce_full_trial_result(result: PosterTrialResult | dict[str, Any]) -> PosterTrialResult:
+    if isinstance(result, PosterTrialResult):
+        return result
+    return PosterTrialResult.from_dict(result)
 
-    n, trial, result = _run_trial((n, trial, seed))
-    result["cache_hit"] = False
-    result.setdefault("timings", {})["cache_hit"] = False
-    cache.set(cache_key, result)
-    return n, trial, result
 
-def _run_mr2s_trial(task: tuple[int, int, int | None]) -> tuple[int, int, dict[str, Any]]:
-    n, trial, seed = task
-    trial_seed = (seed + trial * 100 + n) if seed is not None else None
-    graph = _generate_delaunay_graph(n, trial_seed)
-    res_cls, timings = _run_clustered_solver(graph, n)
-    return n, trial, {
-        "mr2s": res_cls,
-        "timings": timings,
-    }
+def _coerce_mr2s_trial_result(result: Mr2sTrialResult | dict[str, Any]) -> Mr2sTrialResult:
+    if isinstance(result, Mr2sTrialResult):
+        return result
+    return Mr2sTrialResult.from_dict(result)
 
-def _run_mr2s_trial_with_cache(
-    task: tuple[int, int, int | None, str | None]
-) -> tuple[int, int, dict[str, Any]]:
-    n, trial, seed, cache_dir = task
-    if cache_dir is None:
-        n, trial, result = _run_mr2s_trial((n, trial, seed))
-        result["cache_hit"] = False
-        result.setdefault("timings", {})["cache_hit"] = False
-        return n, trial, result
 
-    cache = SimpleCache(cache_dir)
-    cache_key = _poster_mr2s_trial_cache_key(n, trial, seed)
-    cached_result = cache.get(cache_key)
-    if isinstance(cached_result, dict):
-        cached_result["cache_hit"] = True
-        cached_result.setdefault("timings", {})["cache_hit"] = True
-        return n, trial, cached_result
+def _run_trial_worker(
+    task: tuple[int, int, int | None],
+) -> tuple[int, int, PosterTrialResult | dict[str, Any]]:
+    # decorator 안쪽에서 실제 cache hit/miss 처리를 공통화하되,
+    # multiprocessing pickle이 찾을 수 있는 별도 top-level worker 이름을 유지한다.
+    return _run_trial(task)
 
-    n, trial, result = _run_mr2s_trial((n, trial, seed))
-    result["cache_hit"] = False
-    result.setdefault("timings", {})["cache_hit"] = False
-    cache.set(cache_key, result)
-    return n, trial, result
 
-def _process_pool_context() -> multiprocessing.context.BaseContext:
+_run_trial_with_cache = cached_trial_result(
+    cache_key=_poster_trial_cache_key,
+    from_dict=PosterTrialResult.from_dict,
+    coerce_result=_coerce_full_trial_result,
+)(_run_trial_worker)
+
+
+def _run_mr2s_trial_worker(
+    task: tuple[int, int, int | None],
+) -> tuple[int, int, Mr2sTrialResult | dict[str, Any]]:
+    # MR2S-only도 동일한 cache decorator를 공유한다.
+    return _run_mr2s_trial(task)
+
+
+_run_mr2s_trial_with_cache = cached_trial_result(
+    cache_key=_poster_mr2s_trial_cache_key,
+    from_dict=Mr2sTrialResult.from_dict,
+    coerce_result=_coerce_mr2s_trial_result,
+)(
+    _run_mr2s_trial_worker
+)
+
+
+def _process_pool_context() -> Any:
     """Prefer fork where available; fall back to the platform default."""
-    if "fork" in multiprocessing.get_all_start_methods():
-        return multiprocessing.get_context("fork")
-    return multiprocessing.get_context()
+    return TrialScheduler()._process_pool_context()
+
 
 def _iter_completed_trials(
     worker: Any,
@@ -467,49 +233,12 @@ def _iter_completed_trials(
     num_workers: int,
 ) -> Any:
     """Yield trial results from non-daemonic worker processes as they finish."""
-    with concurrent.futures.ProcessPoolExecutor(
-        max_workers=num_workers,
-        mp_context=_process_pool_context(),
-    ) as executor:
-        futures = [executor.submit(worker, task) for task in tasks]
-        for future in concurrent.futures.as_completed(futures):
-            yield future.result()
+    yield from TrialScheduler().iter_completed(worker, tasks, num_workers)
+
 
 def _aggregate_mr2s_results(results: dict[str, Any], trial_results: dict[int, list[dict[str, Any]]]) -> None:
-    results["mr2s"] = {
-        "apsp": [], "flow": [], "qubo_vars": [], "subgraph_size": [],
-        "phys_total": [], "phys_max": [], "phys_mean": [], "phys_min": [],
-        "partition": [],
-    }
+    PosterResultsAggregator().merge_mr2s_only(results, trial_results)
 
-    for n in results["sizes"]:
-        a_cls, f_cls, v_cls, s_cls = [], [], [], []
-        pt_cls, pmax_cls, pmean_cls, pmin_cls = [], [], [], []
-        partitions = []
-
-        print(f"\n>>> Aggregating MR2S-only size n={n}")
-
-        for result in trial_results[n]:
-            res_cls = result["mr2s"]
-            a_cls.append(res_cls["apsp"])
-            f_cls.append(res_cls["flow"])
-            v_cls.append(res_cls["qvars"])
-            s_cls.append(res_cls["sg"])
-            pt_cls.append(res_cls["phys_total"])
-            pmax_cls.append(res_cls["phys_max"])
-            pmean_cls.append(res_cls["phys_mean"])
-            pmin_cls.append(res_cls["phys_min"])
-            partitions.append(res_cls.get("partition", {}))
-
-        results["mr2s"]["apsp"].append(_mean_finite(a_cls))
-        results["mr2s"]["flow"].append(_mean_finite(f_cls))
-        results["mr2s"]["qubo_vars"].append(_mean_finite(v_cls))
-        results["mr2s"]["subgraph_size"].append(_mean_finite(s_cls))
-        results["mr2s"]["phys_total"].append(_mean_finite(pt_cls))
-        results["mr2s"]["phys_max"].append(_mean_finite(pmax_cls))
-        results["mr2s"]["phys_mean"].append(_mean_finite(pmean_cls))
-        results["mr2s"]["phys_min"].append(_mean_finite(pmin_cls))
-        results["mr2s"]["partition"].append(partitions)
 
 def run(
     sizes: list[int],
@@ -520,103 +249,22 @@ def run(
     cache_dir: str | None = None,
     use_cache: bool = True,
 ) -> None:
-    os.makedirs(output_dir, exist_ok=True)
-    if cache_dir is None and use_cache:
-        cache_dir = os.path.join(output_dir, "poster_trial_cache")
-    elif not use_cache:
-        cache_dir = None
-
-    results = {
-        "sizes": sizes,
-        "mr2s": {
-            "apsp": [], "flow": [], "qubo_vars": [], "subgraph_size": [],
-            "phys_total": [], "phys_max": [], "phys_mean": [], "phys_min": [],
-            "partition": [],
-        },
-        "global": {
-            "apsp": [], "flow": [], "qubo_vars": [], "subgraph_size": [],
-            "phys_total": [], "phys_max": [], "phys_mean": [], "phys_min": []
-        },
-        "raw_sa": {"apsp": [], "flow": []},
-        "random": {"apsp": [], "flow": []},
-    }
-
-    tasks = [(n, trial, seed, cache_dir) for n in sizes for trial in range(num_graphs)]
-    total_tasks = len(tasks)
-    effective_workers = (
-        num_workers
-        if num_workers is not None
-        else min(total_tasks, max((os.cpu_count() or 2) - 1, 1))
+    config = PosterRunConfig(
+        sizes=sizes,
+        num_graphs=num_graphs,
+        seed=seed,
+        output_dir=output_dir,
+        num_workers=num_workers,
+        cache_dir=cache_dir,
+        use_cache=use_cache,
     )
+    PosterResultsRunner(
+        config=config,
+        worker=_run_trial_with_cache,
+        progress_printer=_print_trial_progress,
+        plotter=_plot_results,
+    ).run()
 
-    print(
-        f"Starting poster results: {len(sizes)} size(s), "
-        f"{num_graphs} graph(s) each, {effective_workers} worker process(es)."
-    )
-    if cache_dir is not None:
-        print(f"Using poster trial cache: {cache_dir}")
-
-    trial_results: dict[int, list[dict[str, Any]]] = {n: [] for n in sizes}
-
-    if effective_workers == 0:
-        for index, task in enumerate(tasks, start=1):
-            n, trial, result = _run_trial_with_cache(task)
-            _print_trial_progress(index, total_tasks, n, trial, result["timings"])
-            trial_results[n].append(result)
-    else:
-        for index, (n, trial, result) in enumerate(
-            _iter_completed_trials(_run_trial_with_cache, tasks, effective_workers),
-            start=1,
-        ):
-            _print_trial_progress(index, total_tasks, n, trial, result["timings"])
-            trial_results[n].append(result)
-
-    for n in sizes:
-        a_rsa, f_rsa = [], []
-        a_glb, f_glb, v_glb, s_glb, p_glb = [], [], [], [], []
-        a_cls, f_cls, v_cls, s_cls, pt_cls, pmax_cls, pmean_cls, pmin_cls = [], [], [], [], [], [], [], []
-        a_rnd, f_rnd = [], []
-        partitions = []
-
-        print(f"\n>>> Aggregating size n={n}")
-
-        for result in trial_results[n]:
-            res_rsa = result["raw_sa"]
-            res_glb = result["global"]
-            res_cls = result["mr2s"]
-            res_rnd = _normalize_random_baseline(result["random"])
-            # Accumulate
-            a_rsa.append(res_rsa["apsp"]); f_rsa.append(res_rsa["flow"])
-            a_glb.append(res_glb["apsp"]); f_glb.append(res_glb["flow"]); v_glb.append(res_glb["qvars"]); s_glb.append(res_glb["sg"]); p_glb.append(res_glb["pt"])
-            a_cls.append(res_cls["apsp"]); f_cls.append(res_cls["flow"]); v_cls.append(res_cls["qvars"]); s_cls.append(res_cls["sg"])
-            pt_cls.append(res_cls["phys_total"]); pmax_cls.append(res_cls["phys_max"]); pmean_cls.append(res_cls["phys_mean"]); pmin_cls.append(res_cls["phys_min"])
-            partitions.append(res_cls.get("partition", {}))
-            a_rnd.append(res_rnd["apsp"]); f_rnd.append(res_rnd["flow"])
-
-        # Store averages
-        results["raw_sa"]["apsp"].append(_mean_finite(a_rsa))
-        results["raw_sa"]["flow"].append(_mean_finite(f_rsa))
-        results["global"]["apsp"].append(_mean_finite(a_glb))
-        results["global"]["flow"].append(_mean_finite(f_glb))
-        results["global"]["qubo_vars"].append(_mean_finite(v_glb))
-        results["global"]["subgraph_size"].append(_mean_finite(s_glb))
-        results["global"]["phys_total"].append(_mean_finite(p_glb))
-        results["mr2s"]["apsp"].append(_mean_finite(a_cls))
-        results["mr2s"]["flow"].append(_mean_finite(f_cls))
-        results["mr2s"]["qubo_vars"].append(_mean_finite(v_cls))
-        results["mr2s"]["subgraph_size"].append(_mean_finite(s_cls))
-        results["mr2s"]["phys_total"].append(_mean_finite(pt_cls))
-        results["mr2s"]["phys_max"].append(_mean_finite(pmax_cls))
-        results["mr2s"]["phys_mean"].append(_mean_finite(pmean_cls))
-        results["mr2s"]["phys_min"].append(_mean_finite(pmin_cls))
-        results["mr2s"]["partition"].append(partitions)
-        results["random"]["apsp"].append(_mean_finite(a_rnd))
-        results["random"]["flow"].append(_mean_finite(f_rnd))
-
-    with open(os.path.join(output_dir, "poster_results.json"), "w") as f:
-        json.dump(results, f, indent=2)
-
-    _plot_results(results, output_dir)
 
 def run_mr2s_only(
     sizes: list[int],
@@ -628,60 +276,23 @@ def run_mr2s_only(
     use_cache: bool = True,
     source_results_path: str | None = None,
 ) -> None:
-    os.makedirs(output_dir, exist_ok=True)
-    if source_results_path is None:
-        source_results_path = os.path.join(output_dir, "poster_results.json")
-    if not os.path.exists(source_results_path):
-        raise FileNotFoundError(
-            f"MR2S-only mode needs existing results to merge: {source_results_path}"
-        )
-
-    with open(source_results_path) as f:
-        results = json.load(f)
-    results["sizes"] = sizes
-
-    if cache_dir is None and use_cache:
-        cache_dir = os.path.join(output_dir, "poster_mr2s_trial_cache")
-    elif not use_cache:
-        cache_dir = None
-
-    tasks = [(n, trial, seed, cache_dir) for n in sizes for trial in range(num_graphs)]
-    total_tasks = len(tasks)
-    effective_workers = (
-        num_workers
-        if num_workers is not None
-        else min(total_tasks, max((os.cpu_count() or 2) - 1, 1))
+    config = PosterRunConfig(
+        sizes=sizes,
+        num_graphs=num_graphs,
+        seed=seed,
+        output_dir=output_dir,
+        num_workers=num_workers,
+        cache_dir=cache_dir,
+        use_cache=use_cache,
     )
+    Mr2sOnlyPosterResultsRunner(
+        config=config,
+        worker=_run_mr2s_trial_with_cache,
+        progress_printer=_print_mr2s_trial_progress,
+        plotter=_plot_results,
+        source_results_path=source_results_path,
+    ).run()
 
-    print(
-        f"Starting MR2S-only poster results: {len(sizes)} size(s), "
-        f"{num_graphs} graph(s) each, {effective_workers} worker process(es)."
-    )
-    print(f"Merging into: {source_results_path}")
-    if cache_dir is not None:
-        print(f"Using MR2S-only trial cache: {cache_dir}")
-
-    trial_results: dict[int, list[dict[str, Any]]] = {n: [] for n in sizes}
-
-    if effective_workers == 0:
-        for index, task in enumerate(tasks, start=1):
-            n, trial, result = _run_mr2s_trial_with_cache(task)
-            _print_mr2s_trial_progress(index, total_tasks, n, trial, result["timings"])
-            trial_results[n].append(result)
-    else:
-        for index, (n, trial, result) in enumerate(
-            _iter_completed_trials(_run_mr2s_trial_with_cache, tasks, effective_workers),
-            start=1,
-        ):
-            _print_mr2s_trial_progress(index, total_tasks, n, trial, result["timings"])
-            trial_results[n].append(result)
-
-    _aggregate_mr2s_results(results, trial_results)
-
-    with open(os.path.join(output_dir, "poster_results.json"), "w") as f:
-        json.dump(results, f, indent=2)
-
-    _plot_results(results, output_dir)
 
 def _print_trial_progress(
     index: int,
@@ -696,11 +307,13 @@ def _print_trial_progress(
 
     print(
         f"[{index}/{total}] n={n}, trial={trial}: "
+        f"Graph {timings.get('graph', 0.0):.2f}s, "
         f"Raw SA {timings['raw_sa']:.2f}s, "
         f"Global {timings['global_solve']:.2f}s + {timings['global_embed']:.2f}s, "
         f"Clustered {timings['clustered_solve']:.2f}s + {timings['clustered_embed']:.2f}s, "
         f"Random {timings['random']:.2f}s"
     )
+
 
 def _print_mr2s_trial_progress(
     index: int,
@@ -715,15 +328,11 @@ def _print_mr2s_trial_progress(
 
     print(
         f"[{index}/{total}] n={n}, trial={trial}: "
+        f"Graph {timings.get('graph', 0.0):.2f}s, "
         f"Clustered {timings['clustered_solve']:.2f}s + "
         f"{timings['clustered_embed']:.2f}s"
     )
 
-def _plot_results(results: dict, output_dir: str):
-    sizes = results["sizes"]
-    plot_apsp_reduction(sizes, results["random"]["apsp"], results["raw_sa"]["apsp"], results["global"]["apsp"], results["mr2s"]["apsp"], save_path=os.path.join(output_dir, "apsp_reduction.png"))
-    plot_flow_stability(sizes, results["random"]["flow"], results["raw_sa"]["flow"], results["global"]["flow"], results["mr2s"]["flow"], save_path=os.path.join(output_dir, "flow_stability.png"))
-    plot_preprocessing_scalability(sizes, results["global"]["qubo_vars"], results["mr2s"]["qubo_vars"], results["global"]["subgraph_size"], results["mr2s"]["subgraph_size"], global_physical=results["global"].get("phys_total"), clustered_physical_total=results["mr2s"].get("phys_total"), clustered_physical_max=results["mr2s"].get("phys_max"), clustered_physical_mean=results["mr2s"].get("phys_mean"), clustered_physical_min=results["mr2s"].get("phys_min"), save_path=os.path.join(output_dir, "scalability.png"))
 
 def register_parser(subparsers: argparse._SubParsersAction) -> None:
     p = subparsers.add_parser("poster-results", help="Generate visualization data for MR2S poster.")
@@ -760,6 +369,7 @@ def register_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Existing poster_results.json to merge in MR2S-only mode.",
     )
     p.set_defaults(func=_dispatch)
+
 
 def _dispatch(args: argparse.Namespace) -> None:
     if args.mr2s_only:

--- a/src/commands/poster_results_cache.py
+++ b/src/commands/poster_results_cache.py
@@ -1,0 +1,75 @@
+"""Cache decorators for the ``poster-results`` command."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from src.cache import SimpleCache
+
+TrialTask = tuple[int, int, int | None]
+CachedTrialTask = tuple[int, int, int | None, str | None]
+TrialResult = TypeVar("TrialResult")
+
+
+class CachedTrialWorker:
+    """Pickle-safe callable wrapper for cached trial execution."""
+
+    def __init__(
+        self,
+        worker: Callable[[TrialTask], tuple[int, int, Any]],
+        cache_key: Callable[[int, int, int | None], str],
+        from_dict: Callable[[dict[str, Any]], Any],
+        coerce_result: Callable[[Any], Any],
+    ) -> None:
+        self.worker = worker
+        self.cache_key = cache_key
+        self.from_dict = from_dict
+        self.coerce_result = coerce_result
+
+    def __call__(self, task: CachedTrialTask) -> tuple[int, int, Any]:
+        n, trial, seed, cache_dir = task
+        if cache_dir is None:
+            # 캐시를 끈 실행도 progress/JSON 스키마를 동일하게 유지한다.
+            n, trial, result = self.worker((n, trial, seed))
+            result = self.coerce_result(result)
+            result.mark_cache_hit(False)
+            return n, trial, result
+
+        cache = SimpleCache(cache_dir)
+        cache_key = self.cache_key(n, trial, seed)
+        cached_result = cache.get(cache_key)
+        if isinstance(cached_result, dict):
+            # cache hit 표시는 timing에도 전파되어 progress 출력이 짧게 끝난다.
+            result = self.from_dict(cached_result)
+            result.mark_cache_hit(True)
+            return n, trial, result
+
+        n, trial, result = self.worker((n, trial, seed))
+        result = self.coerce_result(result)
+        result.mark_cache_hit(False)
+        cache.set(cache_key, result.to_dict())
+        return n, trial, result
+
+
+def cached_trial_result(
+    cache_key: Callable[[int, int, int | None], str],
+    from_dict: Callable[[dict[str, Any]], TrialResult],
+    coerce_result: Callable[[Any], TrialResult],
+) -> Callable[
+    [Callable[[TrialTask], tuple[int, int, Any]]],
+    Callable[[CachedTrialTask], tuple[int, int, TrialResult]],
+]:
+    """Wrap a trial worker with disk cache read/write behavior."""
+
+    def decorator(
+        worker: Callable[[TrialTask], tuple[int, int, Any]],
+    ) -> Callable[[CachedTrialTask], tuple[int, int, TrialResult]]:
+        return CachedTrialWorker(
+            worker=worker,
+            cache_key=cache_key,
+            from_dict=from_dict,
+            coerce_result=coerce_result,
+        )
+
+    return decorator

--- a/src/commands/poster_results_models.py
+++ b/src/commands/poster_results_models.py
@@ -1,0 +1,361 @@
+"""Typed result models for the ``poster-results`` experiment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class BasicSolverResult:
+    apsp: float
+    flow: float
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BasicSolverResult":
+        return cls(apsp=data["apsp"], flow=data["flow"])
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apsp": self.apsp,
+            "flow": self.flow,
+        }
+
+
+@dataclass
+class GlobalSolverResult(BasicSolverResult):
+    qvars: float
+    subgraph_size: float
+    physical_total: float
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GlobalSolverResult":
+        return cls(
+            apsp=data["apsp"],
+            flow=data["flow"],
+            qvars=data["qvars"],
+            subgraph_size=data["sg"],
+            physical_total=data["pt"],
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apsp": self.apsp,
+            "flow": self.flow,
+            "qvars": self.qvars,
+            "sg": self.subgraph_size,
+            "pt": self.physical_total,
+        }
+
+
+@dataclass
+class Mr2sSolverResult(BasicSolverResult):
+    qvars: float
+    subgraph_size: float
+    phys_total: float
+    phys_max: float
+    phys_mean: float
+    phys_min: float
+    partition: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Mr2sSolverResult":
+        return cls(
+            apsp=data["apsp"],
+            flow=data["flow"],
+            qvars=data["qvars"],
+            subgraph_size=data["sg"],
+            phys_total=data["phys_total"],
+            phys_max=data["phys_max"],
+            phys_mean=data["phys_mean"],
+            phys_min=data["phys_min"],
+            partition=data.get("partition", {}),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apsp": self.apsp,
+            "flow": self.flow,
+            "qvars": self.qvars,
+            "sg": self.subgraph_size,
+            "phys_total": self.phys_total,
+            "phys_max": self.phys_max,
+            "phys_mean": self.phys_mean,
+            "phys_min": self.phys_min,
+            "partition": self.partition,
+        }
+
+
+@dataclass
+class RandomBaselineResult(BasicSolverResult):
+    sample_count: int | None = None
+    strong_sample_count: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "RandomBaselineResult":
+        return cls(
+            apsp=data["apsp"],
+            flow=data["flow"],
+            sample_count=data.get("sample_count"),
+            strong_sample_count=data.get("strong_sample_count"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "apsp": self.apsp,
+            "flow": self.flow,
+        }
+        if self.sample_count is not None:
+            data["sample_count"] = self.sample_count
+        if self.strong_sample_count is not None:
+            data["strong_sample_count"] = self.strong_sample_count
+        return data
+
+    def normalized(self) -> "RandomBaselineResult":
+        # legacy cache는 sample이 없을 때 0점처럼 저장된 경우가 있어 unavailable로 보정한다.
+        missing_legacy_sample = (
+            self.sample_count is None
+            and self.apsp == 0
+            and self.flow == 0
+        )
+        if self.sample_count == 0 or missing_legacy_sample:
+            return RandomBaselineResult(
+                apsp=float("nan"),
+                flow=float("nan"),
+                sample_count=0,
+                strong_sample_count=self.strong_sample_count,
+            )
+        return self
+
+
+@dataclass
+class TrialTimings:
+    values: dict[str, float | bool] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TrialTimings":
+        return cls(values=dict(data))
+
+    def mark_cache_hit(self, cache_hit: bool) -> None:
+        self.values["cache_hit"] = cache_hit
+
+    @property
+    def cache_hit(self) -> bool:
+        return bool(self.values.get("cache_hit"))
+
+    def to_dict(self) -> dict[str, float | bool]:
+        return dict(self.values)
+
+
+@dataclass
+class PosterTrialResult:
+    raw_sa: BasicSolverResult
+    global_result: GlobalSolverResult
+    mr2s: Mr2sSolverResult
+    random: RandomBaselineResult
+    timings: TrialTimings
+    mr2s_variants: dict[str, GlobalSolverResult] = field(default_factory=dict)
+    dnc_strategies: dict[str, Mr2sSolverResult] = field(default_factory=dict)
+    cache_hit: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PosterTrialResult":
+        timings = TrialTimings.from_dict(data.get("timings", {}))
+        cache_hit = bool(data.get("cache_hit", timings.cache_hit))
+        timings.mark_cache_hit(cache_hit)
+        mr2s = Mr2sSolverResult.from_dict(data["mr2s"])
+        dnc_strategies = {
+            name: Mr2sSolverResult.from_dict(result)
+            for name, result in data.get("dnc_strategies", {}).items()
+        }
+        mr2s_variants = {
+            name: GlobalSolverResult.from_dict(result)
+            for name, result in data.get("mr2s_variants", {}).items()
+        }
+        if not dnc_strategies:
+            # 기존 cache/result에는 strategy별 결과가 없으므로 poster 전략으로 보정한다.
+            dnc_strategies["poster"] = mr2s
+        return cls(
+            raw_sa=BasicSolverResult.from_dict(data["raw_sa"]),
+            global_result=GlobalSolverResult.from_dict(data["global"]),
+            mr2s=mr2s,
+            random=RandomBaselineResult.from_dict(data["random"]),
+            timings=timings,
+            mr2s_variants=mr2s_variants,
+            dnc_strategies=dnc_strategies,
+            cache_hit=cache_hit,
+        )
+
+    def mark_cache_hit(self, cache_hit: bool) -> None:
+        self.cache_hit = cache_hit
+        self.timings.mark_cache_hit(cache_hit)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "raw_sa": self.raw_sa.to_dict(),
+            "global": self.global_result.to_dict(),
+            "mr2s": self.mr2s.to_dict(),
+            "mr2s_variants": {
+                name: result.to_dict()
+                for name, result in self.mr2s_variants.items()
+            },
+            "dnc_strategies": {
+                name: result.to_dict()
+                for name, result in self.dnc_strategies.items()
+            },
+            "random": self.random.to_dict(),
+            "timings": self.timings.to_dict(),
+            "cache_hit": self.cache_hit,
+        }
+
+
+@dataclass
+class Mr2sTrialResult:
+    mr2s: Mr2sSolverResult
+    timings: TrialTimings
+    cache_hit: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Mr2sTrialResult":
+        timings = TrialTimings.from_dict(data.get("timings", {}))
+        cache_hit = bool(data.get("cache_hit", timings.cache_hit))
+        timings.mark_cache_hit(cache_hit)
+        return cls(
+            mr2s=Mr2sSolverResult.from_dict(data["mr2s"]),
+            timings=timings,
+            cache_hit=cache_hit,
+        )
+
+    def mark_cache_hit(self, cache_hit: bool) -> None:
+        self.cache_hit = cache_hit
+        self.timings.mark_cache_hit(cache_hit)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mr2s": self.mr2s.to_dict(),
+            "timings": self.timings.to_dict(),
+            "cache_hit": self.cache_hit,
+        }
+
+
+TrialPayload = PosterTrialResult | Mr2sTrialResult
+
+
+@dataclass
+class BasicResultSeries:
+    apsp: list[float] = field(default_factory=list)
+    flow: list[float] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, list[float]]:
+        return {
+            "apsp": self.apsp,
+            "flow": self.flow,
+        }
+
+
+@dataclass
+class GlobalResultSeries(BasicResultSeries):
+    qubo_vars: list[float] = field(default_factory=list)
+    subgraph_size: list[float] = field(default_factory=list)
+    phys_total: list[float] = field(default_factory=list)
+    phys_max: list[float] = field(default_factory=list)
+    phys_mean: list[float] = field(default_factory=list)
+    phys_min: list[float] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, list[float]]:
+        return {
+            "apsp": self.apsp,
+            "flow": self.flow,
+            "qubo_vars": self.qubo_vars,
+            "subgraph_size": self.subgraph_size,
+            "phys_total": self.phys_total,
+            "phys_max": self.phys_max,
+            "phys_mean": self.phys_mean,
+            "phys_min": self.phys_min,
+        }
+
+
+@dataclass
+class Mr2sResultSeries(GlobalResultSeries):
+    partition: list[list[dict[str, Any]]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = super().to_dict()
+        data["partition"] = self.partition
+        return data
+
+
+@dataclass
+class TimingResultSeries:
+    graph: list[float] = field(default_factory=list)
+    raw_sa: list[float] = field(default_factory=list)
+    global_solve: list[float] = field(default_factory=list)
+    global_embed: list[float] = field(default_factory=list)
+    clustered_solve: list[float] = field(default_factory=list)
+    clustered_embed: list[float] = field(default_factory=list)
+    dnc_poster_solve: list[float] = field(default_factory=list)
+    dnc_poster_embed: list[float] = field(default_factory=list)
+    dnc_embedding_aware_solve: list[float] = field(default_factory=list)
+    dnc_embedding_aware_embed: list[float] = field(default_factory=list)
+    dnc_degeneracy_pruning_solve: list[float] = field(default_factory=list)
+    dnc_degeneracy_pruning_embed: list[float] = field(default_factory=list)
+    robbin_mr2s_solve: list[float] = field(default_factory=list)
+    robbin_mr2s_embed: list[float] = field(default_factory=list)
+    iterated_local_search_mr2s_solve: list[float] = field(default_factory=list)
+    iterated_local_search_mr2s_embed: list[float] = field(default_factory=list)
+    random: list[float] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, list[float]]:
+        return {
+            "graph": self.graph,
+            "raw_sa": self.raw_sa,
+            "global_solve": self.global_solve,
+            "global_embed": self.global_embed,
+            "clustered_solve": self.clustered_solve,
+            "clustered_embed": self.clustered_embed,
+            "dnc_poster_solve": self.dnc_poster_solve,
+            "dnc_poster_embed": self.dnc_poster_embed,
+            "dnc_embedding_aware_solve": self.dnc_embedding_aware_solve,
+            "dnc_embedding_aware_embed": self.dnc_embedding_aware_embed,
+            "dnc_degeneracy_pruning_solve": self.dnc_degeneracy_pruning_solve,
+            "dnc_degeneracy_pruning_embed": self.dnc_degeneracy_pruning_embed,
+            "robbin_mr2s_solve": self.robbin_mr2s_solve,
+            "robbin_mr2s_embed": self.robbin_mr2s_embed,
+            "iterated_local_search_mr2s_solve": self.iterated_local_search_mr2s_solve,
+            "iterated_local_search_mr2s_embed": self.iterated_local_search_mr2s_embed,
+            "random": self.random,
+        }
+
+
+@dataclass
+class PosterResultsSummary:
+    sizes: list[int]
+    mr2s: Mr2sResultSeries = field(default_factory=Mr2sResultSeries)
+    global_result: GlobalResultSeries = field(default_factory=GlobalResultSeries)
+    raw_sa: BasicResultSeries = field(default_factory=BasicResultSeries)
+    random: BasicResultSeries = field(default_factory=BasicResultSeries)
+    timings: TimingResultSeries = field(default_factory=TimingResultSeries)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sizes": self.sizes,
+            "mr2s": self.mr2s.to_dict(),
+            "global": self.global_result.to_dict(),
+            "raw_sa": self.raw_sa.to_dict(),
+            "random": self.random.to_dict(),
+            "timings": self.timings.to_dict(),
+        }
+
+
+def coerce_trial_payload(data: TrialPayload | dict[str, Any]) -> TrialPayload:
+    if isinstance(data, (PosterTrialResult, Mr2sTrialResult)):
+        return data
+    if "raw_sa" in data:
+        return PosterTrialResult.from_dict(data)
+    return Mr2sTrialResult.from_dict(data)
+
+
+def payload_to_dict(data: TrialPayload | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(data, (PosterTrialResult, Mr2sTrialResult)):
+        return data.to_dict()
+    return data

--- a/src/commands/poster_results_partition_strategy.py
+++ b/src/commands/poster_results_partition_strategy.py
@@ -1,0 +1,318 @@
+"""DnC partition strategies for poster-result MR2S runs."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import numpy as np
+from mr2s_module import QuboMR2SSolver, estimate_required_qubits
+from mr2s_module.domain.embeddable_graph_partition import EmbeddableGraphPartition
+from mr2s_module.domain.score import EmbeddingEstimate
+from mr2s_module.solver.dnc_mr2s_solver import DnCMr2sSolver
+
+
+def _embedding_estimate_with_status(bqm: Any) -> tuple[EmbeddingEstimate | None, bool, str | None]:
+    try:
+        return estimate_required_qubits(bqm), True, None
+    except RuntimeError as exc:
+        # embedding 실패는 fallback/partition 판단에 필요한 진단값으로 남긴다.
+        return None, False, str(exc)
+
+
+def _estimate_physical_qubits_with_status(bqm: Any) -> tuple[float, bool, str | None]:
+    estimate, can_embed, error = _embedding_estimate_with_status(bqm)
+    physical_qubits = (
+        float(estimate.num_physical_qubits)
+        if estimate is not None
+        else float("nan")
+    )
+    return physical_qubits, can_embed, error
+
+
+def _estimate_physical_qubits(bqm: Any) -> float:
+    """Return physical qubits for embeddable BQMs; NaN when embedding fails."""
+    physical_qubits, _, _ = _estimate_physical_qubits_with_status(bqm)
+    return physical_qubits
+
+
+def _probe_embedding(mr2s_solver: QuboMR2SSolver, graph: Any) -> dict[str, Any]:
+    probe, _ = _probe_embedding_with_estimate(mr2s_solver, graph)
+    return probe
+
+
+def _probe_embedding_with_estimate(
+    mr2s_solver: QuboMR2SSolver,
+    graph: Any,
+) -> tuple[dict[str, Any], EmbeddingEstimate | None]:
+    bqm = mr2s_solver.build_bqm(graph)
+    estimate, can_embed, error = _embedding_estimate_with_status(bqm)
+    physical_qubits = (
+        float(estimate.num_physical_qubits)
+        if estimate is not None
+        else float("nan")
+    )
+    return {
+        "can_embed": can_embed,
+        "qvars": len(bqm.variables),
+        "physical_qubits": physical_qubits,
+        "error": error,
+    }, estimate
+
+
+def _can_recurse_partition(parent: Any, sub_graphs: list[Any]) -> bool:
+    if not sub_graphs:
+        return False
+
+    # 자기 자신과 같은 크기의 subgraph가 나오면 재귀 분할이 진행되지 않는다.
+    parent_edge_count = len(parent.edges)
+    return all(
+        0 < len(sub_graph.edges) < parent_edge_count
+        for sub_graph in sub_graphs
+    )
+
+
+def _partition_with_target_k(face_cycle: Any, graph: Any, target_k: int) -> Any:
+    # face_cycle 객체의 target_k를 임시로 바꾸고 반드시 원래 값으로 복구한다.
+    previous_target_k = face_cycle.target_k
+    face_cycle.target_k = target_k
+    try:
+        return face_cycle.run(graph)
+    finally:
+        face_cycle.target_k = previous_target_k
+
+
+def _summarize_partition_attempt(
+    target_k: int,
+    result: Any,
+    can_recurse: bool,
+    probes: list[dict[str, Any]],
+    accepted: bool,
+) -> dict[str, Any]:
+    sub_graphs = result.sub_graphs
+    # 실패한 embedding은 NaN으로 보존하고, 합산 통계는 유한값만 사용한다.
+    finite_physical = [
+        probe["physical_qubits"]
+        for probe in probes
+        if np.isfinite(probe["physical_qubits"])
+    ]
+    qvars = [probe["qvars"] for probe in probes]
+    return {
+        "target_k": target_k,
+        "subgraph_count": len(sub_graphs),
+        "remaining_edge_count": len(result.remaining_edges),
+        "edge_counts": [len(sub_graph.edges) for sub_graph in sub_graphs],
+        "can_recurse": can_recurse,
+        "all_embed": bool(probes) and all(probe["can_embed"] for probe in probes),
+        "accepted": accepted,
+        "embed_failures": sum(not probe["can_embed"] for probe in probes),
+        "qvars": qvars,
+        "max_qvars": max(qvars) if qvars else 0,
+        "total_qvars": sum(qvars),
+        "physical_qubits": [probe["physical_qubits"] for probe in probes],
+        "physical_total": float(sum(finite_physical)) if finite_physical else float("nan"),
+    }
+
+
+class DncPartitionStrategy:
+    """Find an embeddable DnC partition by varying face-cycle ``target_k``."""
+
+    def __init__(self) -> None:
+        self.last_diagnostics: dict[str, Any] = {}
+        self.last_elapsed_seconds: float = 0.0
+
+    def run(self, graph: Any) -> EmbeddableGraphPartition:
+        if not hasattr(self, "mr2s_solver") or not hasattr(self, "face_cycle"):
+            raise RuntimeError("DncPartitionStrategy requires mr2s_solver and face_cycle")
+
+        start = time.monotonic()
+        partition, diagnostics = self.find_partition(
+            self.mr2s_solver,
+            self.face_cycle,
+            graph,
+        )
+        self.last_elapsed_seconds = time.monotonic() - start
+        self.last_diagnostics = diagnostics
+        return partition
+
+    def divide(self, solver: DnCMr2sSolver, graph: Any) -> tuple[list[Any], dict[str, Any]]:
+        self.mr2s_solver = solver.mr2s_solver
+        self.face_cycle = solver.face_cycle
+        partition = self.run(graph)
+        return partition.sub_graphs, self.last_diagnostics
+
+    def find_partition(
+        self,
+        mr2s_solver: QuboMR2SSolver,
+        face_cycle: Any,
+        graph: Any,
+    ) -> tuple[EmbeddableGraphPartition, dict[str, Any]]:
+        # 먼저 전체 그래프 QUBO가 하드웨어 embedding 가능한지 확인한다.
+        whole_graph_probe, whole_graph_estimate = self.probe_embedding_with_estimate(
+            mr2s_solver,
+            graph,
+        )
+        diagnostics = {
+            "whole_graph": whole_graph_probe,
+            "attempts": [],
+            "selected_reason": "whole_graph_embeddable",
+            "selected_probes": [whole_graph_probe],
+        }
+        if whole_graph_estimate is not None:
+            return EmbeddableGraphPartition(
+                sub_graphs=[graph],
+                embedding_estimates=[whole_graph_estimate],
+                target_k=None,
+            ), diagnostics
+
+        partition, partition_diagnostics = self.find_embeddable_partition_by_target_k(
+            mr2s_solver,
+            face_cycle,
+            graph,
+        )
+        diagnostics.update(partition_diagnostics)
+        if partition is None:
+            # partition을 찾지 못하면 solver가 기존 경로로 처리하도록 전체 그래프를 반환한다.
+            diagnostics["selected_reason"] = "fallback_whole_graph"
+            diagnostics["selected_probes"] = [whole_graph_probe]
+            return EmbeddableGraphPartition(
+                sub_graphs=[graph],
+                embedding_estimates=[],
+                target_k=None,
+            ), diagnostics
+        return partition, diagnostics
+
+    def find_embeddable_partition_by_target_k(
+        self,
+        mr2s_solver: QuboMR2SSolver,
+        face_cycle: Any,
+        graph: Any,
+    ) -> tuple[EmbeddableGraphPartition | None, dict[str, Any]]:
+        left = 2
+        right = max(2, len(graph.edges))
+        best_partition: EmbeddableGraphPartition | None = None
+        best_probes: list[dict[str, Any]] = []
+        attempts: list[dict[str, Any]] = []
+
+        while left <= right:
+            # 가능한 partition 중 embedding이 되는 가장 작은 target_k를 찾는다.
+            target_k = (left + right) // 2
+            result = self.partition_with_target_k(face_cycle, graph, target_k)
+            sub_graphs = result.sub_graphs
+            can_recurse = self.can_recurse_partition(graph, sub_graphs)
+            probes: list[dict[str, Any]] = []
+            estimates: list[EmbeddingEstimate] = []
+            if can_recurse:
+                for sub_graph in sub_graphs:
+                    probe, estimate = self.probe_embedding_with_estimate(
+                        mr2s_solver,
+                        sub_graph,
+                    )
+                    probes.append(probe)
+                    if estimate is not None:
+                        estimates.append(estimate)
+            accepted = can_recurse and all(probe["can_embed"] for probe in probes)
+            attempts.append(
+                self.summarize_partition_attempt(
+                    target_k=target_k,
+                    result=result,
+                    can_recurse=can_recurse,
+                    probes=probes,
+                    accepted=accepted,
+                )
+            )
+
+            if accepted:
+                best_partition = EmbeddableGraphPartition(
+                    sub_graphs=sub_graphs,
+                    embedding_estimates=estimates,
+                    target_k=target_k,
+                )
+                best_probes = probes
+                right = target_k - 1
+            else:
+                left = target_k + 1
+
+        diagnostics = {
+            "attempts": attempts,
+            "selected_reason": "partition_found" if best_partition else "partition_not_found",
+            "selected_probes": best_probes,
+        }
+        return best_partition, diagnostics
+
+    def probe_embedding(self, mr2s_solver: QuboMR2SSolver, graph: Any) -> dict[str, Any]:
+        return _probe_embedding(mr2s_solver, graph)
+
+    def probe_embedding_with_estimate(
+        self,
+        mr2s_solver: QuboMR2SSolver,
+        graph: Any,
+    ) -> tuple[dict[str, Any], EmbeddingEstimate | None]:
+        return _probe_embedding_with_estimate(mr2s_solver, graph)
+
+    def find_partition_by_target_k(
+        self,
+        mr2s_solver: QuboMR2SSolver,
+        face_cycle: Any,
+        graph: Any,
+    ) -> tuple[list[Any], dict[str, Any]]:
+        partition, diagnostics = self.find_embeddable_partition_by_target_k(
+            mr2s_solver,
+            face_cycle,
+            graph,
+        )
+        return (partition.sub_graphs if partition is not None else []), diagnostics
+
+    def partition_with_target_k(self, face_cycle: Any, graph: Any, target_k: int) -> Any:
+        return _partition_with_target_k(face_cycle, graph, target_k)
+
+    def can_recurse_partition(self, parent: Any, sub_graphs: list[Any]) -> bool:
+        return _can_recurse_partition(parent, sub_graphs)
+
+    def summarize_partition_attempt(
+        self,
+        target_k: int,
+        result: Any,
+        can_recurse: bool,
+        probes: list[dict[str, Any]],
+        accepted: bool,
+    ) -> dict[str, Any]:
+        return _summarize_partition_attempt(
+            target_k=target_k,
+            result=result,
+            can_recurse=can_recurse,
+            probes=probes,
+            accepted=accepted,
+        )
+
+
+class TimedPartitionStrategy:
+    """Record elapsed time for any mr2s-module DnC partition strategy."""
+
+    def __init__(self, strategy: Any) -> None:
+        self.strategy = strategy
+        self.last_elapsed_seconds = 0.0
+
+    def run(self, graph: Any) -> EmbeddableGraphPartition:
+        start = time.monotonic()
+        try:
+            return self.strategy.run(graph)
+        finally:
+            # module-provided strategies do not expose timing, so the wrapper keeps it.
+            self.last_elapsed_seconds = time.monotonic() - start
+
+
+def _find_partition_by_target_k_with_diagnostics(
+    mr2s_solver: QuboMR2SSolver,
+    face_cycle: Any,
+    graph: Any,
+) -> tuple[list[Any], dict[str, Any]]:
+    return DncPartitionStrategy().find_partition_by_target_k(
+        mr2s_solver,
+        face_cycle,
+        graph,
+    )
+
+
+def _divide_graph_with_diagnostics(solver: DnCMr2sSolver, graph: Any) -> tuple[list[Any], dict[str, Any]]:
+    return DncPartitionStrategy().divide(solver, graph)

--- a/src/commands/poster_results_plotting.py
+++ b/src/commands/poster_results_plotting.py
@@ -1,0 +1,70 @@
+"""Plotting helpers for the ``poster-results`` command."""
+
+from __future__ import annotations
+
+import os
+
+from src.visualizer import (
+    plot_apsp_reduction,
+    plot_flow_stability,
+    plot_preprocessing_scalability,
+    plot_spent_time,
+)
+
+
+def _plot_results(results: dict, output_dir: str) -> None:
+    sizes = results["sizes"]
+    # solver별 normalized APSP를 한 그래프에 모아 poster용 비교 그림을 만든다.
+    plot_apsp_reduction(
+        sizes,
+        results["random"]["apsp"],
+        results["raw_sa"]["apsp"],
+        results["global"]["apsp"],
+        results["mr2s"]["apsp"],
+        mr2s_variants=results.get("mr2s_variants"),
+        dnc_strategies=results.get("dnc_strategies"),
+        save_path=os.path.join(output_dir, "apsp_reduction.png"),
+    )
+    # 방향 선택이 각 vertex의 in/out 균형을 얼마나 안정적으로 유지하는지 비교한다.
+    plot_flow_stability(
+        sizes,
+        results["random"]["flow"],
+        results["raw_sa"]["flow"],
+        results["global"]["flow"],
+        results["mr2s"]["flow"],
+        mr2s_variants=results.get("mr2s_variants"),
+        dnc_strategies=results.get("dnc_strategies"),
+        save_path=os.path.join(output_dir, "flow_stability.png"),
+    )
+    # global QUBO와 clustered QUBO의 변수 수 및 physical qubit 추정치를 비교한다.
+    plot_preprocessing_scalability(
+        sizes,
+        results["global"]["qubo_vars"],
+        results["mr2s"]["qubo_vars"],
+        results["global"]["subgraph_size"],
+        results["mr2s"]["subgraph_size"],
+        global_physical=results["global"].get("phys_total"),
+        clustered_physical_total=results["mr2s"].get("phys_total"),
+        clustered_physical_max=results["mr2s"].get("phys_max"),
+        clustered_physical_mean=results["mr2s"].get("phys_mean"),
+        clustered_physical_min=results["mr2s"].get("phys_min"),
+        mr2s_variants=results.get("mr2s_variants"),
+        dnc_strategies=results.get("dnc_strategies"),
+        save_path=os.path.join(output_dir, "scalability.png"),
+    )
+    if "timings" in results:
+        # trial별 timing 평균을 size 축으로 모아 stage별 실행 시간을 비교한다.
+        timings = results["timings"]
+        plot_spent_time(
+            sizes,
+            timings.get("graph", []),
+            timings.get("raw_sa", []),
+            timings.get("global_solve", []),
+            timings.get("global_embed", []),
+            timings.get("clustered_solve", []),
+            timings.get("clustered_embed", []),
+            timings.get("random", []),
+            mr2s_variant_timings=timings,
+            dnc_timings=timings,
+            save_path=os.path.join(output_dir, "spent_time.png"),
+        )

--- a/src/commands/poster_results_runner.py
+++ b/src/commands/poster_results_runner.py
@@ -1,0 +1,704 @@
+"""Object-oriented runners for the ``poster-results`` experiment."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import copy
+import json
+import multiprocessing
+import os
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from src.commands.poster_results_models import (
+    Mr2sTrialResult,
+    PosterResultsSummary,
+    PosterTrialResult,
+    TrialPayload,
+    coerce_trial_payload,
+)
+from src.commands.poster_results_solvers import _mean_finite, _normalize_random_baseline
+from src.commands.poster_results_solvers import DNC_STRATEGIES, MR2S_VARIANTS
+
+TrialResult = tuple[int, int, TrialPayload | dict[str, Any]]
+TrialTask = tuple[int, int, int | None, str | None]
+TrialWorker = Callable[[TrialTask], TrialResult]
+ProgressPrinter = Callable[[int, int, int, int, dict[str, float]], None]
+Plotter = Callable[[dict[str, Any], str], None]
+
+RESULT_SERIES_KEYS = {
+    "mr2s": [
+        "apsp", "flow", "qubo_vars", "subgraph_size",
+        "phys_total", "phys_max", "phys_mean", "phys_min", "partition",
+    ],
+    "global": [
+        "apsp", "flow", "qubo_vars", "subgraph_size",
+        "phys_total", "phys_max", "phys_mean", "phys_min",
+    ],
+    "raw_sa": ["apsp", "flow"],
+    "random": ["apsp", "flow"],
+    "timings": [
+        "graph", "raw_sa", "global_solve", "global_embed",
+        "clustered_solve", "clustered_embed", "random",
+        "dnc_poster_solve", "dnc_poster_embed",
+        "dnc_embedding_aware_solve", "dnc_embedding_aware_embed",
+        "dnc_degeneracy_pruning_solve", "dnc_degeneracy_pruning_embed",
+        "robbin_mr2s_solve", "robbin_mr2s_embed",
+        "iterated_local_search_mr2s_solve", "iterated_local_search_mr2s_embed",
+    ],
+}
+
+FULL_TIMING_KEYS = [
+    "graph", "raw_sa", "global_solve", "global_embed",
+    "clustered_solve", "clustered_embed", "random",
+    "dnc_poster_solve", "dnc_poster_embed",
+    "dnc_embedding_aware_solve", "dnc_embedding_aware_embed",
+    "dnc_degeneracy_pruning_solve", "dnc_degeneracy_pruning_embed",
+    "robbin_mr2s_solve", "robbin_mr2s_embed",
+    "iterated_local_search_mr2s_solve", "iterated_local_search_mr2s_embed",
+]
+MR2S_TIMING_KEYS = ["graph", "clustered_solve", "clustered_embed"]
+
+
+def _coerce_full_result(result: PosterTrialResult | dict[str, Any]) -> PosterTrialResult:
+    if isinstance(result, PosterTrialResult):
+        return result
+    return PosterTrialResult.from_dict(result)
+
+
+def _coerce_mr2s_result(result: Mr2sTrialResult | dict[str, Any]) -> Mr2sTrialResult:
+    if isinstance(result, Mr2sTrialResult):
+        return result
+    return Mr2sTrialResult.from_dict(result)
+
+
+@dataclass(frozen=True)
+class PosterRunConfig:
+    sizes: list[int]
+    num_graphs: int
+    seed: int | None
+    output_dir: str
+    num_workers: int | None = None
+    cache_dir: str | None = None
+    use_cache: bool = True
+
+    def resolved_cache_dir(self, default_name: str) -> str | None:
+        if not self.use_cache:
+            return None
+        if self.cache_dir is not None:
+            return self.cache_dir
+        return os.path.join(self.output_dir, default_name)
+
+    def with_sizes(self, sizes: list[int]) -> "PosterRunConfig":
+        return PosterRunConfig(
+            sizes=sizes,
+            num_graphs=self.num_graphs,
+            seed=self.seed,
+            output_dir=self.output_dir,
+            num_workers=self.num_workers,
+            cache_dir=self.cache_dir,
+            use_cache=self.use_cache,
+        )
+
+
+class TrialScheduler:
+    """Trial 실행 방식을 캡슐화해 순차/병렬 실행 정책을 교체하기 쉽게 한다."""
+
+    def effective_workers(self, total_tasks: int, requested_workers: int | None) -> int:
+        if requested_workers is not None:
+            return requested_workers
+        return min(total_tasks, max((os.cpu_count() or 2) - 1, 1))
+
+    def iter_completed(
+        self,
+        worker: TrialWorker,
+        tasks: list[TrialTask],
+        num_workers: int,
+    ) -> Any:
+        if num_workers == 0:
+            for task in tasks:
+                yield worker(task)
+            return
+
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=num_workers,
+            mp_context=self._process_pool_context(),
+        ) as executor:
+            futures = [executor.submit(worker, task) for task in tasks]
+            for future in concurrent.futures.as_completed(futures):
+                yield future.result()
+
+    def _process_pool_context(self) -> multiprocessing.context.BaseContext:
+        # mr2s solver 객체는 spawn보다 fork에서 초기화 비용과 pickle 제약이 적다.
+        if "fork" in multiprocessing.get_all_start_methods():
+            return multiprocessing.get_context("fork")
+        return multiprocessing.get_context()
+
+
+class PosterResultsAggregator:
+    """Solver별 trial 결과를 poster_results.json 스키마로 집계한다."""
+
+    def empty_results(self, sizes: list[int]) -> dict[str, Any]:
+        return PosterResultsSummary(sizes=sizes).to_dict()
+
+    def aggregate_full(
+        self,
+        sizes: list[int],
+        trial_results: dict[int, list[PosterTrialResult | dict[str, Any]]],
+    ) -> dict[str, Any]:
+        summary = PosterResultsSummary(sizes=sizes)
+        dnc_strategy_summary = {
+            name: {
+                "apsp": [], "flow": [], "qubo_vars": [], "subgraph_size": [],
+                "phys_total": [], "phys_max": [], "phys_mean": [], "phys_min": [],
+                "partition": [],
+            }
+            for name in DNC_STRATEGIES
+        }
+        mr2s_variant_summary = {
+            name: {
+                "apsp": [], "flow": [], "qubo_vars": [], "subgraph_size": [],
+                "phys_total": [],
+            }
+            for name in MR2S_VARIANTS
+        }
+
+        for n in sizes:
+            # full run은 네 solver 계열의 trial 결과를 같은 size 축으로 집계한다.
+            a_rsa, f_rsa = [], []
+            a_glb, f_glb, v_glb, s_glb, p_glb = [], [], [], [], []
+            a_cls, f_cls, v_cls, s_cls = [], [], [], []
+            pt_cls, pmax_cls, pmean_cls, pmin_cls = [], [], [], []
+            a_rnd, f_rnd = [], []
+            timing_values = {key: [] for key in FULL_TIMING_KEYS}
+            partitions = []
+            strategy_values = {
+                name: {
+                    "apsp": [], "flow": [], "qvars": [], "subgraph_size": [],
+                    "phys_total": [], "phys_max": [], "phys_mean": [], "phys_min": [],
+                    "partition": [],
+                }
+                for name in DNC_STRATEGIES
+            }
+            variant_values = {
+                name: {
+                    "apsp": [], "flow": [], "qvars": [], "subgraph_size": [],
+                    "phys_total": [],
+                }
+                for name in MR2S_VARIANTS
+            }
+
+            print(f"\n>>> Aggregating size n={n}")
+
+            for raw_result in trial_results[n]:
+                result = _coerce_full_result(raw_result)
+                res_rnd = _normalize_random_baseline(result.random)
+                a_rsa.append(result.raw_sa.apsp)
+                f_rsa.append(result.raw_sa.flow)
+                a_glb.append(result.global_result.apsp)
+                f_glb.append(result.global_result.flow)
+                v_glb.append(result.global_result.qvars)
+                s_glb.append(result.global_result.subgraph_size)
+                p_glb.append(result.global_result.physical_total)
+                a_cls.append(result.mr2s.apsp)
+                f_cls.append(result.mr2s.flow)
+                v_cls.append(result.mr2s.qvars)
+                s_cls.append(result.mr2s.subgraph_size)
+                pt_cls.append(result.mr2s.phys_total)
+                pmax_cls.append(result.mr2s.phys_max)
+                pmean_cls.append(result.mr2s.phys_mean)
+                pmin_cls.append(result.mr2s.phys_min)
+                partitions.append(result.mr2s.partition)
+                for strategy_name, strategy_result in result.dnc_strategies.items():
+                    if strategy_name not in strategy_values:
+                        continue
+                    strategy_values[strategy_name]["apsp"].append(strategy_result.apsp)
+                    strategy_values[strategy_name]["flow"].append(strategy_result.flow)
+                    strategy_values[strategy_name]["qvars"].append(strategy_result.qvars)
+                    strategy_values[strategy_name]["subgraph_size"].append(strategy_result.subgraph_size)
+                    strategy_values[strategy_name]["phys_total"].append(strategy_result.phys_total)
+                    strategy_values[strategy_name]["phys_max"].append(strategy_result.phys_max)
+                    strategy_values[strategy_name]["phys_mean"].append(strategy_result.phys_mean)
+                    strategy_values[strategy_name]["phys_min"].append(strategy_result.phys_min)
+                    strategy_values[strategy_name]["partition"].append(strategy_result.partition)
+                for variant_name, variant_result in result.mr2s_variants.items():
+                    if variant_name not in variant_values:
+                        continue
+                    variant_values[variant_name]["apsp"].append(variant_result.apsp)
+                    variant_values[variant_name]["flow"].append(variant_result.flow)
+                    variant_values[variant_name]["qvars"].append(variant_result.qvars)
+                    variant_values[variant_name]["subgraph_size"].append(variant_result.subgraph_size)
+                    variant_values[variant_name]["phys_total"].append(variant_result.physical_total)
+                a_rnd.append(res_rnd.apsp)
+                f_rnd.append(res_rnd.flow)
+                self._collect_timings(result.timings.to_dict(), timing_values)
+
+            summary.raw_sa.apsp.append(_mean_finite(a_rsa))
+            summary.raw_sa.flow.append(_mean_finite(f_rsa))
+            summary.global_result.apsp.append(_mean_finite(a_glb))
+            summary.global_result.flow.append(_mean_finite(f_glb))
+            summary.global_result.qubo_vars.append(_mean_finite(v_glb))
+            summary.global_result.subgraph_size.append(_mean_finite(s_glb))
+            summary.global_result.phys_total.append(_mean_finite(p_glb))
+            summary.mr2s.apsp.append(_mean_finite(a_cls))
+            summary.mr2s.flow.append(_mean_finite(f_cls))
+            summary.mr2s.qubo_vars.append(_mean_finite(v_cls))
+            summary.mr2s.subgraph_size.append(_mean_finite(s_cls))
+            summary.mr2s.phys_total.append(_mean_finite(pt_cls))
+            summary.mr2s.phys_max.append(_mean_finite(pmax_cls))
+            summary.mr2s.phys_mean.append(_mean_finite(pmean_cls))
+            summary.mr2s.phys_min.append(_mean_finite(pmin_cls))
+            summary.mr2s.partition.append(partitions)
+            for strategy_name, values in strategy_values.items():
+                target = dnc_strategy_summary[strategy_name]
+                target["apsp"].append(_mean_finite(values["apsp"]))
+                target["flow"].append(_mean_finite(values["flow"]))
+                target["qubo_vars"].append(_mean_finite(values["qvars"]))
+                target["subgraph_size"].append(_mean_finite(values["subgraph_size"]))
+                target["phys_total"].append(_mean_finite(values["phys_total"]))
+                target["phys_max"].append(_mean_finite(values["phys_max"]))
+                target["phys_mean"].append(_mean_finite(values["phys_mean"]))
+                target["phys_min"].append(_mean_finite(values["phys_min"]))
+                target["partition"].append(values["partition"])
+            for variant_name, values in variant_values.items():
+                target = mr2s_variant_summary[variant_name]
+                target["apsp"].append(_mean_finite(values["apsp"]))
+                target["flow"].append(_mean_finite(values["flow"]))
+                target["qubo_vars"].append(_mean_finite(values["qvars"]))
+                target["subgraph_size"].append(_mean_finite(values["subgraph_size"]))
+                target["phys_total"].append(_mean_finite(values["phys_total"]))
+            summary.random.apsp.append(_mean_finite(a_rnd))
+            summary.random.flow.append(_mean_finite(f_rnd))
+            self._append_timings(summary.timings, timing_values)
+
+        data = summary.to_dict()
+        data["dnc_strategies"] = dnc_strategy_summary
+        data["mr2s_variants"] = mr2s_variant_summary
+        return data
+
+    def merge_full_results(
+        self,
+        existing: dict[str, Any] | None,
+        computed: dict[str, Any],
+    ) -> dict[str, Any]:
+        if existing is None:
+            return computed
+        merged = _merge_results_by_size(existing, computed, replace_sections=set(RESULT_SERIES_KEYS))
+        merged = _merge_nested_results_by_size(
+            merged, existing, computed, "dnc_strategies", replace_existing=True
+        )
+        return _merge_nested_results_by_size(
+            merged, existing, computed, "mr2s_variants", replace_existing=True
+        )
+
+    def merge_mr2s_only(
+        self,
+        results: dict[str, Any],
+        trial_results: dict[int, list[Mr2sTrialResult | dict[str, Any]]],
+    ) -> dict[str, Any]:
+        requested_sizes = set(trial_results)
+        missing_sizes = [size for size in requested_sizes if size not in results.get("sizes", [])]
+        if missing_sizes:
+            raise ValueError(
+                "MR2S-only mode can only update sizes already present in existing results: "
+                f"{sorted(missing_sizes)}"
+            )
+
+        partial_results = PosterResultsSummary(sizes=list(trial_results)).to_dict()
+        mr2s_summary = PosterResultsSummary(sizes=list(trial_results)).mr2s
+
+        for n in trial_results:
+            # 각 size의 trial 값을 먼저 모은 뒤 NaN/Infinity를 제외하고 평균낸다.
+            a_cls, f_cls, v_cls, s_cls = [], [], [], []
+            pt_cls, pmax_cls, pmean_cls, pmin_cls = [], [], [], []
+            timing_values = {key: [] for key in MR2S_TIMING_KEYS}
+            partitions = []
+
+            print(f"\n>>> Aggregating MR2S-only size n={n}")
+
+            for raw_result in trial_results[n]:
+                result = _coerce_mr2s_result(raw_result)
+                res_cls = result.mr2s
+                a_cls.append(res_cls.apsp)
+                f_cls.append(res_cls.flow)
+                v_cls.append(res_cls.qvars)
+                s_cls.append(res_cls.subgraph_size)
+                pt_cls.append(res_cls.phys_total)
+                pmax_cls.append(res_cls.phys_max)
+                pmean_cls.append(res_cls.phys_mean)
+                pmin_cls.append(res_cls.phys_min)
+                partitions.append(res_cls.partition)
+                self._collect_timings(result.timings.to_dict(), timing_values)
+
+            mr2s_summary.apsp.append(_mean_finite(a_cls))
+            mr2s_summary.flow.append(_mean_finite(f_cls))
+            mr2s_summary.qubo_vars.append(_mean_finite(v_cls))
+            mr2s_summary.subgraph_size.append(_mean_finite(s_cls))
+            mr2s_summary.phys_total.append(_mean_finite(pt_cls))
+            mr2s_summary.phys_max.append(_mean_finite(pmax_cls))
+            mr2s_summary.phys_mean.append(_mean_finite(pmean_cls))
+            mr2s_summary.phys_min.append(_mean_finite(pmin_cls))
+            mr2s_summary.partition.append(partitions)
+            self._ensure_timing_section(partial_results)
+            self._append_timings_to_dict(partial_results["timings"], timing_values)
+
+        partial_results["mr2s"] = mr2s_summary.to_dict()
+        # 기존 poster_results.json의 다른 solver 결과와 요청하지 않은 MR2S size를 유지한다.
+        merged = _merge_results_by_size(results, partial_results, replace_sections={"mr2s"})
+        return _merge_timing_keys_by_size(
+            merged,
+            partial_results,
+            replace_keys=set(MR2S_TIMING_KEYS),
+        )
+
+    def _collect_timings(
+        self,
+        timings: dict[str, Any],
+        timing_values: dict[str, list[float]],
+    ) -> None:
+        for key in timing_values:
+            value = timings.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                timing_values[key].append(float(value))
+
+    def _append_timings(
+        self,
+        timing_series: Any,
+        timing_values: dict[str, list[float]],
+    ) -> None:
+        for key, values in timing_values.items():
+            getattr(timing_series, key).append(_mean_finite(values))
+
+    def _ensure_timing_section(self, results: dict[str, Any]) -> None:
+        results.setdefault("timings", {key: [] for key in RESULT_SERIES_KEYS["timings"]})
+
+    def _append_timings_to_dict(
+        self,
+        timing_series: dict[str, list[float]],
+        timing_values: dict[str, list[float]],
+    ) -> None:
+        for key, values in timing_values.items():
+            timing_series.setdefault(key, []).append(_mean_finite(values))
+
+
+def _merge_results_by_size(
+    existing: dict[str, Any],
+    updates: dict[str, Any],
+    replace_sections: set[str],
+) -> dict[str, Any]:
+    merged = copy.deepcopy(existing)
+    existing_sizes = list(existing.get("sizes", []))
+    update_sizes = list(updates.get("sizes", []))
+    output_sizes = existing_sizes + [size for size in update_sizes if size not in existing_sizes]
+    merged["sizes"] = output_sizes
+
+    existing_size_set = set(existing_sizes)
+    update_size_set = set(update_sizes)
+
+    for section, keys in RESULT_SERIES_KEYS.items():
+        merged.setdefault(section, {})
+        for key in keys:
+            existing_by_size = _series_by_size(existing, section, key)
+            update_by_size = _series_by_size(updates, section, key)
+            values = []
+            has_value = False
+
+            for size in output_sizes:
+                use_update = size in update_size_set and (
+                    section in replace_sections or size not in existing_size_set
+                )
+                value_found = False
+                value = None
+
+                if use_update and size in update_by_size:
+                    value = update_by_size[size]
+                    value_found = True
+                elif size in existing_by_size:
+                    value = existing_by_size[size]
+                    value_found = True
+                elif size in update_by_size:
+                    value = update_by_size[size]
+                    value_found = True
+                elif section == "timings" and update_by_size:
+                    value = float("nan")
+                    value_found = True
+
+                if value_found:
+                    values.append(value)
+                    has_value = True
+
+            if has_value:
+                merged[section][key] = values
+            elif key in merged[section]:
+                merged[section][key] = []
+
+    return merged
+
+
+def _merge_timing_keys_by_size(
+    existing: dict[str, Any],
+    updates: dict[str, Any],
+    replace_keys: set[str],
+) -> dict[str, Any]:
+    merged = copy.deepcopy(existing)
+    merged.setdefault("timings", {})
+    existing_sizes = list(existing.get("sizes", []))
+    update_sizes = list(updates.get("sizes", []))
+    output_sizes = list(merged.get("sizes", existing_sizes))
+    update_size_set = set(update_sizes)
+
+    for key in RESULT_SERIES_KEYS["timings"]:
+        existing_by_size = _series_by_size(existing, "timings", key)
+        update_by_size = _series_by_size(updates, "timings", key)
+        values = []
+        has_value = False
+
+        for size in output_sizes:
+            if key in replace_keys and size in update_size_set and size in update_by_size:
+                values.append(update_by_size[size])
+                has_value = True
+            elif size in existing_by_size:
+                values.append(existing_by_size[size])
+                has_value = True
+            elif size in update_by_size:
+                values.append(update_by_size[size])
+                has_value = True
+
+        if has_value:
+            merged["timings"][key] = values
+
+    return merged
+
+
+def _merge_nested_results_by_size(
+    merged: dict[str, Any],
+    existing: dict[str, Any],
+    updates: dict[str, Any],
+    section: str,
+    replace_existing: bool,
+) -> dict[str, Any]:
+    output_sizes = list(merged.get("sizes", []))
+    update_sizes = set(updates.get("sizes", []))
+    existing_sizes = set(existing.get("sizes", []))
+    merged.setdefault(section, {})
+
+    item_names = set(existing.get(section, {})) | set(updates.get(section, {}))
+    for item_name in item_names:
+        merged[section].setdefault(item_name, {})
+        keys = set(existing.get(section, {}).get(item_name, {}))
+        keys |= set(updates.get(section, {}).get(item_name, {}))
+
+        for key in keys:
+            existing_by_size = _nested_series_by_size(existing, section, item_name, key)
+            update_by_size = _nested_series_by_size(updates, section, item_name, key)
+            values = []
+            has_value = False
+            for size in output_sizes:
+                use_update = size in update_sizes and (
+                    replace_existing or size not in existing_sizes
+                )
+                if use_update and size in update_by_size:
+                    values.append(update_by_size[size])
+                    has_value = True
+                elif size in existing_by_size:
+                    values.append(existing_by_size[size])
+                    has_value = True
+                elif size in update_by_size:
+                    values.append(update_by_size[size])
+                    has_value = True
+            if has_value:
+                merged[section][item_name][key] = values
+    return merged
+
+
+def _nested_series_by_size(
+    results: dict[str, Any],
+    section: str,
+    item_name: str,
+    key: str,
+) -> dict[int, Any]:
+    sizes = results.get("sizes", [])
+    values = results.get(section, {}).get(item_name, {}).get(key, [])
+    return {
+        size: values[index]
+        for index, size in enumerate(sizes)
+        if index < len(values)
+    }
+
+
+def _series_by_size(results: dict[str, Any], section: str, key: str) -> dict[int, Any]:
+    sizes = results.get("sizes", [])
+    values = results.get(section, {}).get(key, [])
+    return {
+        size: values[index]
+        for index, size in enumerate(sizes)
+        if index < len(values)
+    }
+
+
+class PosterResultsRunner:
+    """Full poster experiment runner.
+
+    새 solver나 metric을 넣으려면 trial worker나 aggregator를 교체하면 된다.
+    """
+
+    cache_name = "poster_trial_cache"
+
+    def __init__(
+        self,
+        config: PosterRunConfig,
+        worker: TrialWorker,
+        progress_printer: ProgressPrinter,
+        plotter: Plotter,
+        scheduler: TrialScheduler | None = None,
+        aggregator: PosterResultsAggregator | None = None,
+    ) -> None:
+        self.config = config
+        self.worker = worker
+        self.progress_printer = progress_printer
+        self.plotter = plotter
+        self.scheduler = scheduler or TrialScheduler()
+        self.aggregator = aggregator or PosterResultsAggregator()
+
+    def run(self) -> dict[str, Any]:
+        # initial dir cache
+        os.makedirs(self.config.output_dir, exist_ok=True)
+        existing_results = self._load_existing_results()
+        run_sizes = self._sizes_to_compute(existing_results)
+        cache_dir = self.config.resolved_cache_dir(self.cache_name)
+
+        # initial tasks
+        tasks = self._build_tasks(cache_dir, run_sizes)
+        total_tasks = len(tasks)
+        workers = self.scheduler.effective_workers(total_tasks, self.config.num_workers)
+
+        print(
+            f"Starting poster results: {len(run_sizes)} new size(s), "
+            f"{self.config.num_graphs} graph(s) each, {workers} worker process(es)."
+        )
+        if existing_results is not None:
+            reused_sizes = [size for size in self.config.sizes if size in existing_results.get("sizes", [])]
+            if reused_sizes:
+                print(f"Reusing existing poster results for size(s): {reused_sizes}")
+        if cache_dir is not None:
+            print(f"Using poster trial cache: {cache_dir}")
+
+        if tasks:
+            trial_results = self._collect_trials(tasks, workers, total_tasks, run_sizes)
+            computed_results = self.aggregator.aggregate_full(run_sizes, trial_results)
+            results = self.aggregator.merge_full_results(existing_results, computed_results)
+        elif existing_results is not None:
+            results = existing_results
+        else:
+            results = self.aggregator.empty_results(self.config.sizes)
+
+        self._write_results(results)
+        self.plotter(results, self.config.output_dir)
+        return results
+
+    def _load_existing_results(self) -> dict[str, Any] | None:
+        if not self.config.use_cache:
+            return None
+        results_path = os.path.join(self.config.output_dir, "poster_results.json")
+        if not os.path.exists(results_path):
+            return None
+        with open(results_path) as f:
+            return json.load(f)
+
+    def _sizes_to_compute(self, existing_results: dict[str, Any] | None) -> list[int]:
+        if existing_results is None:
+            return self.config.sizes
+        existing_sizes = set(existing_results.get("sizes", []))
+        return [size for size in self.config.sizes if size not in existing_sizes]
+
+    def _build_tasks(self, cache_dir: str | None, sizes: list[int]) -> list[TrialTask]:
+        return [
+            (n, trial, self.config.seed, cache_dir)
+            for n in sizes
+            for trial in range(self.config.num_graphs)
+        ]
+
+    def _collect_trials(
+        self,
+        tasks: list[TrialTask],
+        workers: int,
+        total_tasks: int,
+        sizes: list[int],
+    ) -> dict[int, list[TrialPayload]]:
+        trial_results: dict[int, list[TrialPayload]] = {
+            n: [] for n in sizes
+        }
+        for index, (n, trial, raw_result) in enumerate(
+            self.scheduler.iter_completed(self.worker, tasks, workers),
+            start=1,
+        ):
+            result = coerce_trial_payload(raw_result)
+            self.progress_printer(index, total_tasks, n, trial, result.timings.to_dict())
+            trial_results[n].append(result)
+        return trial_results
+
+    def _write_results(self, results: dict[str, Any]) -> None:
+        with open(os.path.join(self.config.output_dir, "poster_results.json"), "w") as f:
+            json.dump(results, f, indent=2)
+
+
+class Mr2sOnlyPosterResultsRunner(PosterResultsRunner):
+    """기존 poster 결과에 MR2S 결과만 다시 계산해 병합하는 runner."""
+
+    cache_name = "poster_mr2s_trial_cache"
+
+    def __init__(
+        self,
+        config: PosterRunConfig,
+        worker: TrialWorker,
+        progress_printer: ProgressPrinter,
+        plotter: Plotter,
+        source_results_path: str | None = None,
+        scheduler: TrialScheduler | None = None,
+        aggregator: PosterResultsAggregator | None = None,
+    ) -> None:
+        super().__init__(
+            config=config,
+            worker=worker,
+            progress_printer=progress_printer,
+            plotter=plotter,
+            scheduler=scheduler,
+            aggregator=aggregator,
+        )
+        self.source_results_path = source_results_path
+
+    def run(self) -> dict[str, Any]:
+        os.makedirs(self.config.output_dir, exist_ok=True)
+        source_results_path = self._source_results_path()
+        if not os.path.exists(source_results_path):
+            # MR2S-only는 기존 baseline 결과에 merge하는 모드이므로 원본 JSON이 필요하다.
+            raise FileNotFoundError(
+                f"MR2S-only mode needs existing results to merge: {source_results_path}"
+            )
+
+        with open(source_results_path) as f:
+            results = json.load(f)
+
+        cache_dir = self.config.resolved_cache_dir(self.cache_name)
+        tasks = self._build_tasks(cache_dir, self.config.sizes)
+        total_tasks = len(tasks)
+        workers = self.scheduler.effective_workers(total_tasks, self.config.num_workers)
+
+        print(
+            f"Starting MR2S-only poster results: {len(self.config.sizes)} size(s), "
+            f"{self.config.num_graphs} graph(s) each, {workers} worker process(es)."
+        )
+        print(f"Merging into: {source_results_path}")
+        if cache_dir is not None:
+            print(f"Using MR2S-only trial cache: {cache_dir}")
+
+        trial_results = self._collect_trials(tasks, workers, total_tasks, self.config.sizes)
+        merged = self.aggregator.merge_mr2s_only(results, trial_results)
+        self._write_results(merged)
+        self.plotter(merged, self.config.output_dir)
+        return merged
+
+    def _source_results_path(self) -> str:
+        if self.source_results_path is not None:
+            return self.source_results_path
+        return os.path.join(self.config.output_dir, "poster_results.json")

--- a/src/commands/poster_results_runner.py
+++ b/src/commands/poster_results_runner.py
@@ -401,31 +401,25 @@ def _merge_results_by_size(
             existing_by_size = _series_by_size(existing, section, key)
             update_by_size = _series_by_size(updates, section, key)
             values = []
-            has_value = False
+            has_value = bool(existing_by_size or update_by_size)
 
             for size in output_sizes:
                 use_update = size in update_size_set and (
                     section in replace_sections or size not in existing_size_set
                 )
-                value_found = False
-                value = None
 
                 if use_update and size in update_by_size:
                     value = update_by_size[size]
-                    value_found = True
                 elif size in existing_by_size:
                     value = existing_by_size[size]
-                    value_found = True
                 elif size in update_by_size:
                     value = update_by_size[size]
-                    value_found = True
-                elif section == "timings" and update_by_size:
-                    value = float("nan")
-                    value_found = True
+                elif has_value:
+                    value = _missing_series_value(key)
+                else:
+                    continue
 
-                if value_found:
-                    values.append(value)
-                    has_value = True
+                values.append(value)
 
             if has_value:
                 merged[section][key] = values
@@ -451,18 +445,17 @@ def _merge_timing_keys_by_size(
         existing_by_size = _series_by_size(existing, "timings", key)
         update_by_size = _series_by_size(updates, "timings", key)
         values = []
-        has_value = False
+        has_value = bool(existing_by_size or update_by_size)
 
         for size in output_sizes:
             if key in replace_keys and size in update_size_set and size in update_by_size:
                 values.append(update_by_size[size])
-                has_value = True
             elif size in existing_by_size:
                 values.append(existing_by_size[size])
-                has_value = True
             elif size in update_by_size:
                 values.append(update_by_size[size])
-                has_value = True
+            elif has_value:
+                values.append(_missing_series_value(key))
 
         if has_value:
             merged["timings"][key] = values
@@ -492,23 +485,28 @@ def _merge_nested_results_by_size(
             existing_by_size = _nested_series_by_size(existing, section, item_name, key)
             update_by_size = _nested_series_by_size(updates, section, item_name, key)
             values = []
-            has_value = False
+            has_value = bool(existing_by_size or update_by_size)
             for size in output_sizes:
                 use_update = size in update_sizes and (
                     replace_existing or size not in existing_sizes
                 )
                 if use_update and size in update_by_size:
                     values.append(update_by_size[size])
-                    has_value = True
                 elif size in existing_by_size:
                     values.append(existing_by_size[size])
-                    has_value = True
                 elif size in update_by_size:
                     values.append(update_by_size[size])
-                    has_value = True
+                elif has_value:
+                    values.append(_missing_series_value(key))
             if has_value:
                 merged[section][item_name][key] = values
     return merged
+
+
+def _missing_series_value(key: str) -> Any:
+    if key == "partition":
+        return []
+    return float("nan")
 
 
 def _nested_series_by_size(

--- a/src/commands/poster_results_runner.py
+++ b/src/commands/poster_results_runner.py
@@ -688,7 +688,7 @@ class Mr2sOnlyPosterResultsRunner(PosterResultsRunner):
             f"Starting MR2S-only poster results: {len(self.config.sizes)} size(s), "
             f"{self.config.num_graphs} graph(s) each, {workers} worker process(es)."
         )
-        print(f"Merging into: {source_results_path}")
+        print(f"Merging source results from: {source_results_path}")
         if cache_dir is not None:
             print(f"Using MR2S-only trial cache: {cache_dir}")
 

--- a/src/commands/poster_results_solvers.py
+++ b/src/commands/poster_results_solvers.py
@@ -217,7 +217,7 @@ def _build_dnc_qubo_solver(
         mr2s_solver=_build_qubo_solver(),
     )
     if partition_strategy is not None:
-        # mr2s-module 0.0.7의 graph_partition_strategy hook에 poster용 전략을 주입한다.
+        # mr2s-module 0.0.8의 graph_partition_strategy hook에 poster용 전략을 주입한다.
         partition_strategy.mr2s_solver = solver.mr2s_solver
         partition_strategy.face_cycle = solver.face_cycle
         solver.graph_partition_strategy = partition_strategy

--- a/src/commands/poster_results_solvers.py
+++ b/src/commands/poster_results_solvers.py
@@ -1,0 +1,469 @@
+"""Solver and trial helpers for the ``poster-results`` command."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import mr2s_module.domain.graph
+import networkx as nx
+import numpy as np
+from mr2s_module import (
+    ApspSumRanker,
+    Evaluator,
+    FlowPolyGenerator,
+    NHop,
+    NHopPolyGenerator,
+    QuboMR2SSolver,
+    Robbin,
+    SAMR2SSolver,
+    SAQuboSolver,
+    SmallWorldSpec,
+)
+from mr2s_module.edge_orient.iterated_local_search import IteratedLocalSearch
+from mr2s_module.solver.dnc_mr2s_solver import DnCMr2sSolver
+from mr2s_module.solver.dnc_graph_partition_strategy import (
+    DegeneracyPruningFaceCyclePartitionStrategy,
+    EmbeddingAwareFaceCyclePartitionStrategy,
+)
+
+from src.commands.face_k_analysis import _generate_delaunay_graph, _nx_to_mr2s_graph
+from src.commands.poster_results_models import (
+    BasicSolverResult,
+    GlobalSolverResult,
+    Mr2sSolverResult,
+    Mr2sTrialResult,
+    PosterTrialResult,
+    RandomBaselineResult,
+    TrialTimings,
+)
+from src.commands.poster_results_partition_strategy import (
+    DncPartitionStrategy,
+    TimedPartitionStrategy,
+    _can_recurse_partition,
+    _divide_graph_with_diagnostics,
+    _estimate_physical_qubits,
+    _estimate_physical_qubits_with_status,
+    _find_partition_by_target_k_with_diagnostics,
+    _partition_with_target_k,
+    _probe_embedding,
+    _summarize_partition_attempt,
+)
+from src.score_calculator import calculate_apsp_sum_and_nhop_neighbor_counts
+
+# mr2s_module의 Graph 구현에 is_empty가 없는 버전이 있어 런타임에서 보강한다.
+if not hasattr(mr2s_module.domain.graph.Graph, "is_empty"):
+    def is_empty(self):
+        return len(self.edges) == 0
+
+    mr2s_module.domain.graph.Graph.is_empty = is_empty
+
+
+spec = SmallWorldSpec([NHop(2, 1), NHop(3, 1)])
+DNC_STRATEGIES = ["poster", "embedding_aware", "degeneracy_pruning"]
+MR2S_VARIANTS = ["robbin_mr2s", "iterated_local_search_mr2s"]
+
+
+def _as_finite_or_nan(value: Any) -> float:
+    value = float(value)
+    return value if np.isfinite(value) else float("nan")
+
+
+def _mean_finite(values: list[float]) -> float:
+    # embedding 실패 등으로 생긴 NaN/Infinity는 평균에서 제외한다.
+    finite_values = [_as_finite_or_nan(value) for value in values]
+    finite_values = [value for value in finite_values if np.isfinite(value)]
+    if not finite_values:
+        return float("nan")
+    return float(np.mean(finite_values))
+
+
+def _normalize_random_baseline(result: RandomBaselineResult | dict[str, Any]) -> RandomBaselineResult | dict[str, Any]:
+    """Treat missing random samples as unavailable, not as a zero score."""
+    if isinstance(result, RandomBaselineResult):
+        return result.normalized()
+
+    sample_count = result.get("sample_count")
+    # 예전 캐시는 random sample이 없을 때 0점처럼 저장된 경우가 있어 NaN으로 보정한다.
+    missing_legacy_sample = sample_count is None and result.get("apsp") == 0 and result.get("flow") == 0
+    if sample_count == 0 or missing_legacy_sample:
+        normalized = dict(result)
+        normalized["apsp"] = float("nan")
+        normalized["flow"] = float("nan")
+        normalized["sample_count"] = 0
+        return normalized
+    return result
+
+
+def _sample_random_orientations(
+    graph: nx.Graph,
+    max_samples: int,
+    seed: int | None = None,
+) -> list[nx.DiGraph]:
+    """Sample arbitrary edge orientations without filtering by connectivity."""
+    if max_samples < 1:
+        raise ValueError(f"max_samples must be >= 1, got {max_samples}")
+
+    edges = list(graph.edges())
+    nodes = list(graph.nodes())
+    rng = np.random.default_rng(seed)
+    orientations: list[nx.DiGraph] = []
+
+    for _ in range(max_samples):
+        # 각 undirected edge마다 난수 bit 하나로 방향을 선택한다.
+        dg = nx.DiGraph()
+        dg.add_nodes_from(nodes)
+        bits = rng.integers(0, 2, size=len(edges))
+        for bit, (u, v) in zip(bits, edges):
+            if bit == 0:
+                dg.add_edge(u, v)
+            else:
+                dg.add_edge(v, u)
+        orientations.append(dg)
+
+    return orientations
+
+
+def _flow_imbalance_score(graph: nx.DiGraph) -> int:
+    return sum(
+        (graph.in_degree(node) - graph.out_degree(node)) ** 2
+        for node in graph.nodes()
+    )
+
+
+def _calculate_random_baseline(
+    graph: nx.Graph,
+    n: int,
+    seed: int | None,
+    max_samples: int = 10,
+) -> RandomBaselineResult:
+    random_samples = _sample_random_orientations(graph, max_samples=max_samples, seed=seed)
+    trial_apsp = []
+    trial_flow = []
+
+    for orient in random_samples:
+        # APSP는 강연결 샘플만 평균에 넣고, flow는 모든 random orientation의 분포를 본다.
+        if nx.is_strongly_connected(orient):
+            apsp, _ = calculate_apsp_sum_and_nhop_neighbor_counts(orient, hops=[])
+            trial_apsp.append(apsp / (n * (n - 1)))
+        trial_flow.append(_flow_imbalance_score(orient))
+
+    return RandomBaselineResult(
+        apsp=_mean_finite(trial_apsp),
+        flow=_mean_finite(trial_flow),
+        sample_count=len(random_samples),
+        strong_sample_count=len(trial_apsp),
+    )
+
+
+def _build_sa_solver(seed: int | None = None) -> SAMR2SSolver:
+    return SAMR2SSolver(
+        evaluator=Evaluator(),
+        random_seed=seed,
+    )
+
+
+def _build_qubo_solver(edge_orienter: Any | None = None) -> QuboMR2SSolver:
+    # poster 실험에서는 2-hop/3-hop small-world 항과 flow 항을 함께 사용한다.
+    n_hop_poly = NHopPolyGenerator()
+    n_hop_poly.small_world_spec = spec
+    return QuboMR2SSolver(
+        edge_orienter=edge_orienter,
+        qubo_solver=SAQuboSolver(ApspSumRanker()),
+        evaluator=Evaluator(),
+        poly_generators=[n_hop_poly, FlowPolyGenerator()],
+    )
+
+
+def _build_edge_orienter(variant_name: str) -> Any:
+    if variant_name == "robbin_mr2s":
+        return Robbin()
+    if variant_name == "iterated_local_search_mr2s":
+        return IteratedLocalSearch()
+    raise ValueError(f"Unknown MR2S variant: {variant_name}")
+
+
+def _run_oriented_mr2s_solver(
+    graph: nx.Graph,
+    n: int,
+    variant_name: str,
+) -> tuple[GlobalSolverResult, TrialTimings]:
+    timings = TrialTimings()
+
+    start = time.monotonic()
+    solver = _build_qubo_solver(edge_orienter=_build_edge_orienter(variant_name))
+    sol = solver.run(_nx_to_mr2s_graph(graph))
+    timings.values[f"{variant_name}_solve"] = time.monotonic() - start
+
+    start = time.monotonic()
+    embed_solver = _build_qubo_solver(edge_orienter=_build_edge_orienter(variant_name))
+    bqm = embed_solver.build_bqm(_nx_to_mr2s_graph(graph))
+    physical_qubits = _estimate_physical_qubits(bqm)
+    timings.values[f"{variant_name}_embed"] = time.monotonic() - start
+
+    return GlobalSolverResult(
+        apsp=sol.score.apsp_sum / (n * (n - 1)),
+        flow=sol.score.flow_score,
+        qvars=len(bqm.variables),
+        subgraph_size=len(bqm.variables),
+        physical_total=physical_qubits,
+    ), timings
+
+
+def _build_dnc_qubo_solver(
+    partition_strategy: Any | None = None,
+) -> DnCMr2sSolver:
+    solver = DnCMr2sSolver(
+        mr2s_solver=_build_qubo_solver(),
+    )
+    if partition_strategy is not None:
+        # mr2s-module 0.0.7의 graph_partition_strategy hook에 poster용 전략을 주입한다.
+        partition_strategy.mr2s_solver = solver.mr2s_solver
+        partition_strategy.face_cycle = solver.face_cycle
+        solver.graph_partition_strategy = partition_strategy
+    return solver
+
+
+def _build_partition_strategy(strategy_name: str, solver: DnCMr2sSolver) -> Any:
+    if strategy_name == "poster":
+        strategy = DncPartitionStrategy()
+        strategy.mr2s_solver = solver.mr2s_solver
+        strategy.face_cycle = solver.face_cycle
+        return strategy
+    if strategy_name == "embedding_aware":
+        return TimedPartitionStrategy(
+            EmbeddingAwareFaceCyclePartitionStrategy(
+                mr2s_solver=solver.mr2s_solver,
+                face_cycle=solver.face_cycle,
+                target_graph=solver.target_graph,
+            )
+        )
+    if strategy_name == "degeneracy_pruning":
+        return TimedPartitionStrategy(
+            DegeneracyPruningFaceCyclePartitionStrategy(
+                mr2s_solver=solver.mr2s_solver,
+                face_cycle=solver.face_cycle,
+                target_graph=solver.target_graph,
+            )
+        )
+    raise ValueError(f"Unknown DnC partition strategy: {strategy_name}")
+
+
+def _physical_qubit_stats(values: list[float]) -> dict[str, float]:
+    # embedding 실패 NaN은 통계에서 제외하고, 모두 실패했을 때만 NaN 통계를 낸다.
+    finite_values = [value for value in values if not np.isnan(value)]
+    if not finite_values:
+        return {
+            "total": float("nan"),
+            "max": float("nan"),
+            "mean": float("nan"),
+            "min": float("nan"),
+        }
+    return {
+        "total": float(sum(finite_values)),
+        "max": float(max(finite_values)),
+        "mean": float(np.mean(finite_values)),
+        "min": float(min(finite_values)),
+    }
+
+
+def _diagnostics_from_solution(strategy_name: str, sol_cls: Any) -> dict[str, Any]:
+    estimates = list(getattr(sol_cls, "embedding_estimates", []) or [])
+    sub_graphs = list(getattr(sol_cls, "sub_graphs", []) or [])
+    probes = [
+        {
+            "can_embed": True,
+            "qvars": estimate.num_logical_variables,
+            "physical_qubits": float(estimate.num_physical_qubits),
+            "error": None,
+        }
+        for estimate in estimates
+    ]
+    return {
+        "strategy": strategy_name,
+        "selected_reason": "module_strategy",
+        "partition_target_k": getattr(sol_cls, "partition_target_k", None),
+        "selected_probes": probes,
+        "subgraph_edge_counts": [len(sub_graph.edges) for sub_graph in sub_graphs],
+    }
+
+
+def _failed_dnc_result(strategy_name: str, error: Exception) -> Mr2sSolverResult:
+    return Mr2sSolverResult(
+        apsp=float("nan"),
+        flow=float("nan"),
+        qvars=float("nan"),
+        subgraph_size=float("nan"),
+        phys_total=float("nan"),
+        phys_max=float("nan"),
+        phys_mean=float("nan"),
+        phys_min=float("nan"),
+        partition={
+            "strategy": strategy_name,
+            "selected_reason": "failed",
+            "error": str(error),
+        },
+    )
+
+
+def _run_dnc_strategy_solver(
+    graph: Any,
+    n: int,
+    strategy_name: str,
+) -> tuple[Mr2sSolverResult, TrialTimings]:
+    timings = TrialTimings()
+
+    # strategy별 DnC solver를 별도로 실행해 같은 graph에서 partition 정책을 비교한다.
+    start = time.monotonic()
+    solver_cls = _build_dnc_qubo_solver()
+    partition_strategy = _build_partition_strategy(strategy_name, solver_cls)
+    solver_cls.graph_partition_strategy = partition_strategy
+    graph_cls = _nx_to_mr2s_graph(graph)
+    try:
+        sol_cls = solver_cls.run(graph_cls)
+    except RuntimeError as exc:
+        elapsed = time.monotonic() - start
+        timings.values[f"dnc_{strategy_name}_solve"] = 0.0
+        timings.values[f"dnc_{strategy_name}_embed"] = elapsed
+        if strategy_name == "poster":
+            timings.values["clustered_solve"] = 0.0
+            timings.values["clustered_embed"] = elapsed
+        return _failed_dnc_result(strategy_name, exc), timings
+
+    partition_diagnostics = getattr(partition_strategy, "last_diagnostics", None)
+    if not partition_diagnostics:
+        partition_diagnostics = _diagnostics_from_solution(strategy_name, sol_cls)
+    clustered_total = time.monotonic() - start
+    clustered_embed = getattr(partition_strategy, "last_elapsed_seconds", 0.0)
+    # DnCMr2sSolver.run() 안에서 partition/embed가 먼저 실행되므로 solve 시간에서 분리한다.
+    solve_time = max(0.0, clustered_total - clustered_embed)
+    timings.values[f"dnc_{strategy_name}_solve"] = solve_time
+    timings.values[f"dnc_{strategy_name}_embed"] = clustered_embed
+    if strategy_name == "poster":
+        timings.values["clustered_solve"] = solve_time
+        timings.values["clustered_embed"] = clustered_embed
+
+    selected_probes = partition_diagnostics.get("selected_probes", [])
+    # qvars가 0인 trivial subgraph는 resource 통계에서 제외한다.
+    cluster_phys = [
+        probe["physical_qubits"]
+        for probe in selected_probes
+        if probe["qvars"] > 0
+    ]
+    cluster_qvars = [
+        probe["qvars"]
+        for probe in selected_probes
+        if probe["qvars"] > 0
+    ]
+
+    if not cluster_qvars:
+        cluster_qvars = [0]
+    if not cluster_phys:
+        cluster_phys = [0]
+
+    phys_cls = _physical_qubit_stats(cluster_phys)
+
+    return Mr2sSolverResult(
+        apsp=sol_cls.score.apsp_sum / (n * (n - 1)),
+        flow=sol_cls.score.flow_score,
+        qvars=sum(cluster_qvars),
+        subgraph_size=max(cluster_qvars),
+        phys_total=phys_cls["total"],
+        phys_max=phys_cls["max"],
+        phys_mean=phys_cls["mean"],
+        phys_min=phys_cls["min"],
+        partition=partition_diagnostics,
+    ), timings
+
+
+def _run_clustered_solver(graph: Any, n: int) -> tuple[Mr2sSolverResult, TrialTimings]:
+    return _run_dnc_strategy_solver(graph, n, "poster")
+
+
+def _run_trial(task: tuple[int, int, int | None]) -> tuple[int, int, PosterTrialResult]:
+    """Run all poster-result solvers for one graph trial."""
+    n, trial, seed = task
+    # size와 trial index를 seed에 섞어 size별 그래프가 재현 가능하면서도 서로 달라지게 한다.
+    trial_seed = (seed + trial * 100 + n) if seed is not None else None
+    timings = TrialTimings()
+
+    # graph 생성 시간도 solver 시간과 분리해서 기록한다.
+    start = time.monotonic()
+    graph = _generate_delaunay_graph(n, trial_seed)
+    timings.values["graph"] = time.monotonic() - start
+
+    # 1. Raw SA baseline
+    start = time.monotonic()
+    solver_rsa = _build_sa_solver(seed=trial_seed)
+    solver_rsa.face_cycle = None
+    sol_rsa = solver_rsa.run(_nx_to_mr2s_graph(graph))
+    timings.values["raw_sa"] = time.monotonic() - start
+    res_rsa = BasicSolverResult(
+        apsp=sol_rsa.score.apsp_sum / (n * (n - 1)),
+        flow=sol_rsa.score.flow_score,
+    )
+
+    # 2. 전체 그래프를 하나의 QUBO로 푸는 global baseline
+    start = time.monotonic()
+    solver_glb = _build_qubo_solver()
+    solver_glb.face_cycle = None
+    sol_glb = solver_glb.run(_nx_to_mr2s_graph(graph))
+    timings.values["global_solve"] = time.monotonic() - start
+
+    start = time.monotonic()
+    bqm_glb = solver_glb.build_bqm(_nx_to_mr2s_graph(graph))
+    phys_glb = _estimate_physical_qubits(bqm_glb)
+    timings.values["global_embed"] = time.monotonic() - start
+
+    res_glb = GlobalSolverResult(
+        apsp=sol_glb.score.apsp_sum / (n * (n - 1)),
+        flow=sol_glb.score.flow_score,
+        qvars=len(bqm_glb.variables),
+        subgraph_size=len(bqm_glb.variables),
+        physical_total=phys_glb,
+    )
+
+    # 3. 분할-병합 기반 MR2S solver를 strategy별로 실행한다.
+    mr2s_variant_results: dict[str, GlobalSolverResult] = {}
+    for variant_name in MR2S_VARIANTS:
+        result, variant_timings = _run_oriented_mr2s_solver(graph, n, variant_name)
+        mr2s_variant_results[variant_name] = result
+        timings.values.update(variant_timings.values)
+
+    # 4. 분할-병합 기반 MR2S solver를 strategy별로 실행한다.
+    dnc_strategy_results: dict[str, Mr2sSolverResult] = {}
+    for strategy_name in DNC_STRATEGIES:
+        result, strategy_timings = _run_dnc_strategy_solver(graph, n, strategy_name)
+        dnc_strategy_results[strategy_name] = result
+        timings.values.update(strategy_timings.values)
+    res_cls = dnc_strategy_results["poster"]
+
+    # 5. 임의 방향 baseline
+    start = time.monotonic()
+    res_rnd = _calculate_random_baseline(graph, n, trial_seed)
+    timings.values["random"] = time.monotonic() - start
+
+    return n, trial, PosterTrialResult(
+        raw_sa=res_rsa,
+        global_result=res_glb,
+        mr2s=res_cls,
+        mr2s_variants=mr2s_variant_results,
+        dnc_strategies=dnc_strategy_results,
+        random=res_rnd,
+        timings=timings,
+    )
+
+
+def _run_mr2s_trial(task: tuple[int, int, int | None]) -> tuple[int, int, Mr2sTrialResult]:
+    n, trial, seed = task
+    # MR2S-only 모드는 같은 seed 규칙으로 그래프를 재생성해 기존 결과와 병합한다.
+    trial_seed = (seed + trial * 100 + n) if seed is not None else None
+    start = time.monotonic()
+    graph = _generate_delaunay_graph(n, trial_seed)
+    graph_time = time.monotonic() - start
+    res_cls, timings = _run_clustered_solver(graph, n)
+    timings.values["graph"] = graph_time
+    return n, trial, Mr2sTrialResult(
+        mr2s=res_cls,
+        timings=timings,
+    )

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -14,6 +14,16 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 
+DNC_STRATEGY_STYLES = {
+    "poster": ("D-", "red", "DnC poster"),
+    "embedding_aware": ("^-", "green", "DnC embedding-aware"),
+    "degeneracy_pruning": ("v-", "purple", "DnC degeneracy-pruning"),
+}
+MR2S_VARIANT_STYLES = {
+    "robbin_mr2s": ("P-", "brown", "Robbin + MR2S"),
+    "iterated_local_search_mr2s": ("*-", "teal", "ILS + MR2S"),
+}
+
 
 def plot_score_correlations(
     apsp_sums: Sequence[float],
@@ -302,6 +312,8 @@ def plot_apsp_reduction(
     raw_sa_apsp: list[float],
     global_apsp: list[float],
     clustered_apsp: list[float],
+    mr2s_variants: dict[str, dict] | None = None,
+    dnc_strategies: dict[str, dict] | None = None,
     save_path: str | None = None,
 ) -> plt.Figure:
     """Plot APSP reduction comparing Random, Raw SA, Global (QUBO), and Clustered (DnC)."""
@@ -309,7 +321,13 @@ def plot_apsp_reduction(
     plt.plot(sizes, random_apsp, "o-", label="Random Orientation", color="gray", alpha=0.6)
     plt.plot(sizes, raw_sa_apsp, "x--", label="Raw SA (SAMR2SSolver)", color="orange")
     plt.plot(sizes, global_apsp, "s-", label="Global (QuboMR2SSolver)", color="blue")
-    plt.plot(sizes, clustered_apsp, "D-", label="Clustered (DnCMr2sSolver)", color="red", linewidth=2)
+    for name, section in (mr2s_variants or {}).items():
+        marker, color, label = MR2S_VARIANT_STYLES.get(name, ("P-", None, name.replace("_", " ")))
+        plt.plot(sizes, section.get("apsp", []), marker, label=label, color=color, linewidth=2)
+    strategies = dnc_strategies or {"poster": {"apsp": clustered_apsp}}
+    for name, section in strategies.items():
+        marker, color, label = DNC_STRATEGY_STYLES.get(name, ("D-", None, f"DnC {name}"))
+        plt.plot(sizes, section.get("apsp", []), marker, label=label, color=color, linewidth=2)
     plt.xlabel("Graph Size (Number of Vertices)", fontsize=12)
     plt.ylabel("Normalized APSP Sum", fontsize=12)
     plt.title("APSP Reduction: Comparison of Solvers", fontsize=14)
@@ -327,6 +345,8 @@ def plot_flow_stability(
     raw_sa_flow: list[float],
     global_flow: list[float],
     clustered_flow: list[float],
+    mr2s_variants: dict[str, dict] | None = None,
+    dnc_strategies: dict[str, dict] | None = None,
     save_path: str | None = None,
 ) -> plt.Figure:
     """Plot Flow Stability comparing Random, Raw SA, Global (QUBO), and Clustered (DnC)."""
@@ -334,7 +354,13 @@ def plot_flow_stability(
     plt.plot(sizes, random_flow, "o-", label="Random Orientation", color="gray", alpha=0.6)
     plt.plot(sizes, raw_sa_flow, "x--", label="Raw SA (SAMR2SSolver)", color="orange")
     plt.plot(sizes, global_flow, "s-", label="Global (QuboMR2SSolver)", color="blue")
-    plt.plot(sizes, clustered_flow, "D-", label="Clustered (DnCMr2sSolver)", color="red", linewidth=2)
+    for name, section in (mr2s_variants or {}).items():
+        marker, color, label = MR2S_VARIANT_STYLES.get(name, ("P-", None, name.replace("_", " ")))
+        plt.plot(sizes, section.get("flow", []), marker, label=label, color=color, linewidth=2)
+    strategies = dnc_strategies or {"poster": {"flow": clustered_flow}}
+    for name, section in strategies.items():
+        marker, color, label = DNC_STRATEGY_STYLES.get(name, ("D-", None, f"DnC {name}"))
+        plt.plot(sizes, section.get("flow", []), marker, label=label, color=color, linewidth=2)
     plt.xlabel("Graph Size (Number of Vertices)", fontsize=12)
     plt.ylabel("Flow Imbalance Score Σ(In-Out)²", fontsize=12)
     plt.title("Flow Stability: Comparison of Solvers", fontsize=14)
@@ -357,6 +383,8 @@ def plot_preprocessing_scalability(
     clustered_physical_max: list[float] | None = None,
     clustered_physical_mean: list[float] | None = None,
     clustered_physical_min: list[float] | None = None,
+    mr2s_variants: dict[str, dict] | None = None,
+    dnc_strategies: dict[str, dict] | None = None,
     save_path: str | None = None,
 ) -> plt.Figure:
     """Plot Preprocessing Scalability (Global QUBO vs Clustered DnC)."""
@@ -368,7 +396,13 @@ def plot_preprocessing_scalability(
     # 1. QUBO Variables
     ax1 = axes[0]
     ax1.plot(sizes, global_vars, "s-", label="Global (Full Graph)", color="blue")
-    ax1.plot(sizes, clustered_vars, "D-", label="Clustered (DnC)", color="red", linewidth=2)
+    for name, section in (mr2s_variants or {}).items():
+        marker, color, label = MR2S_VARIANT_STYLES.get(name, ("P-", None, name.replace("_", " ")))
+        ax1.plot(sizes, section.get("qubo_vars", []), marker, label=label, color=color, linewidth=2)
+    strategies = dnc_strategies or {"poster": {"qubo_vars": clustered_vars, "subgraph_size": clustered_sg}}
+    for name, section in strategies.items():
+        marker, color, label = DNC_STRATEGY_STYLES.get(name, ("D-", None, f"DnC {name}"))
+        ax1.plot(sizes, section.get("qubo_vars", []), marker, label=label, color=color, linewidth=2)
     ax1.set_xlabel("Graph Size (Vertices)", fontsize=12)
     ax1.set_ylabel("Number of QUBO Variables", fontsize=12)
     ax1.set_title("QUBO Complexity Reduction", fontsize=14)
@@ -378,7 +412,12 @@ def plot_preprocessing_scalability(
     # 2. Subgraph Size
     ax2 = axes[1]
     ax2.plot(sizes, global_sg, "s-", label="Global (Full Graph)", color="blue")
-    ax2.plot(sizes, clustered_sg, "D-", label="Clustered (Max Subgraph)", color="red", linewidth=2)
+    for name, section in (mr2s_variants or {}).items():
+        marker, color, label = MR2S_VARIANT_STYLES.get(name, ("P-", None, name.replace("_", " ")))
+        ax2.plot(sizes, section.get("subgraph_size", []), marker, label=label, color=color, linewidth=2)
+    for name, section in strategies.items():
+        marker, color, label = DNC_STRATEGY_STYLES.get(name, ("D-", None, f"DnC {name}"))
+        ax2.plot(sizes, section.get("subgraph_size", []), marker, label=label, color=color, linewidth=2)
     ax2.set_xlabel("Graph Size (Vertices)", fontsize=12)
     ax2.set_ylabel("Max QUBO Variables in One Subgraph", fontsize=12)
     ax2.set_title("Subgraph Size Reduction", fontsize=14)
@@ -389,7 +428,12 @@ def plot_preprocessing_scalability(
     if global_physical is not None and clustered_physical_total is not None:
         ax3 = axes[2]
         ax3.plot(sizes, global_physical, "s-", label="Global Total", color="blue", alpha=0.8)
-        ax3.plot(sizes, clustered_physical_total, "D-", label="Clustered Total", color="red", linewidth=2)
+        for name, section in (mr2s_variants or {}).items():
+            marker, color, label = MR2S_VARIANT_STYLES.get(name, ("P-", None, name.replace("_", " ")))
+            ax3.plot(sizes, section.get("phys_total", []), marker, label=f"{label} total", color=color, linewidth=2)
+        for name, section in strategies.items():
+            marker, color, label = DNC_STRATEGY_STYLES.get(name, ("D-", None, f"DnC {name}"))
+            ax3.plot(sizes, section.get("phys_total", []), marker, label=f"{label} total", color=color, linewidth=2)
 
         if clustered_physical_max:
             ax3.plot(sizes, clustered_physical_max, "^--", label="Clustered Max", color="orange")
@@ -405,6 +449,45 @@ def plot_preprocessing_scalability(
         ax3.grid(True, linestyle="--", alpha=0.7)
 
     plt.tight_layout()
+    if save_path:
+        plt.savefig(save_path, dpi=300)
+    return fig
+
+
+def plot_spent_time(
+    sizes: list[int],
+    graph_time: list[float],
+    raw_sa_time: list[float],
+    global_solve_time: list[float],
+    global_embed_time: list[float],
+    clustered_solve_time: list[float],
+    clustered_embed_time: list[float],
+    random_time: list[float],
+    mr2s_variant_timings: dict[str, list[float]] | None = None,
+    dnc_timings: dict[str, list[float]] | None = None,
+    save_path: str | None = None,
+) -> plt.Figure:
+    """Plot mean spent time by graph size for each poster-results stage."""
+    fig = plt.figure(figsize=(10, 6))
+    plt.plot(sizes, graph_time, "o-", label="Graph generation", color="black", alpha=0.7)
+    plt.plot(sizes, raw_sa_time, "x--", label="Raw SA", color="orange")
+    plt.plot(sizes, global_solve_time, "s-", label="Global solve", color="blue")
+    for name, (marker, color, label) in MR2S_VARIANT_STYLES.items():
+        values = (mr2s_variant_timings or {}).get(f"{name}_solve", [])
+        if values:
+            plt.plot(sizes, values, marker, label=f"{label} solve", color=color, linewidth=2)
+    timings = dnc_timings or {"dnc_poster_solve": clustered_solve_time}
+    for name, (marker, color, label) in DNC_STRATEGY_STYLES.items():
+        values = timings.get(f"dnc_{name}_solve", [])
+        if values:
+            plt.plot(sizes, values, marker, label=f"{label} solve", color=color, linewidth=2)
+    plt.plot(sizes, random_time, "o--", label="Random baseline", color="gray", alpha=0.7)
+    plt.xlabel("Graph Size (Vertices)", fontsize=12)
+    plt.ylabel("Mean Spent Time (seconds)", fontsize=12)
+    plt.title("Spent Time by Stage", fontsize=14)
+    plt.legend()
+    plt.grid(True, linestyle="--", alpha=0.7)
+
     if save_path:
         plt.savefig(save_path, dpi=300)
     return fig

--- a/tests/test_poster_results_cmd.py
+++ b/tests/test_poster_results_cmd.py
@@ -14,6 +14,9 @@ from src.commands.poster_results_runner import (
     PosterResultsAggregator,
     PosterResultsRunner,
     PosterRunConfig,
+    RESULT_SERIES_KEYS,
+    _merge_nested_results_by_size,
+    _merge_results_by_size,
 )
 from src.commands.poster_results_models import Mr2sSolverResult, TrialTimings
 
@@ -166,6 +169,87 @@ def test_run_reuses_existing_aggregate_results_for_all_solvers(tmp_path, monkeyp
     assert merged["raw_sa"]["apsp"][1] == 9.0
     assert math.isnan(merged["timings"]["graph"][0])
     assert merged["timings"]["graph"][1] == 29.0
+
+
+def test_merge_results_pads_missing_series_for_old_result_schema() -> None:
+    existing = {
+        "sizes": [5],
+        "mr2s": {"apsp": [1.0]},
+        "timings": {"global_solve": [2.0]},
+    }
+    updates = {
+        "sizes": [10],
+        "mr2s": {
+            "apsp": [10.0],
+            "partition": [[{"selected_reason": "new"}]],
+        },
+        "timings": {
+            "global_solve": [20.0],
+            "robbin_mr2s_solve": [30.0],
+        },
+    }
+
+    merged = _merge_results_by_size(
+        existing,
+        updates,
+        replace_sections=set(RESULT_SERIES_KEYS),
+    )
+
+    assert merged["sizes"] == [5, 10]
+    assert merged["mr2s"]["apsp"] == [1.0, 10.0]
+    assert merged["mr2s"]["partition"] == [[], [{"selected_reason": "new"}]]
+    assert merged["timings"]["global_solve"] == [2.0, 20.0]
+    assert math.isnan(merged["timings"]["robbin_mr2s_solve"][0])
+    assert merged["timings"]["robbin_mr2s_solve"][1] == 30.0
+
+
+def test_merge_nested_results_pads_missing_strategy_and_variant_sizes() -> None:
+    existing = {
+        "sizes": [5],
+        "dnc_strategies": {},
+        "mr2s_variants": {},
+    }
+    updates = {
+        "sizes": [10],
+        "dnc_strategies": {
+            "poster": {
+                "apsp": [10.0],
+                "partition": [[{"selected_reason": "new"}]],
+            },
+        },
+        "mr2s_variants": {
+            "robbin_mr2s": {
+                "apsp": [20.0],
+                "phys_total": [21.0],
+            },
+        },
+    }
+    merged = {"sizes": [5, 10]}
+
+    merged = _merge_nested_results_by_size(
+        merged,
+        existing,
+        updates,
+        "dnc_strategies",
+        replace_existing=True,
+    )
+    merged = _merge_nested_results_by_size(
+        merged,
+        existing,
+        updates,
+        "mr2s_variants",
+        replace_existing=True,
+    )
+
+    assert math.isnan(merged["dnc_strategies"]["poster"]["apsp"][0])
+    assert merged["dnc_strategies"]["poster"]["apsp"][1] == 10.0
+    assert merged["dnc_strategies"]["poster"]["partition"] == [
+        [],
+        [{"selected_reason": "new"}],
+    ]
+    assert math.isnan(merged["mr2s_variants"]["robbin_mr2s"]["apsp"][0])
+    assert merged["mr2s_variants"]["robbin_mr2s"]["apsp"][1] == 20.0
+    assert len(merged["mr2s_variants"]["robbin_mr2s"]["phys_total"]) == 2
 
 
 def test_runner_accepts_custom_aggregator_and_plotter(tmp_path) -> None:

--- a/tests/test_poster_results_cmd.py
+++ b/tests/test_poster_results_cmd.py
@@ -7,7 +7,15 @@ import json
 from types import SimpleNamespace
 from typing import Any
 
+import networkx as nx
+
 from src.commands import poster_results as pr
+from src.commands.poster_results_runner import (
+    PosterResultsAggregator,
+    PosterResultsRunner,
+    PosterRunConfig,
+)
+from src.commands.poster_results_models import Mr2sSolverResult, TrialTimings
 
 
 def _fake_trial(task: tuple[int, int, int | None]) -> tuple[int, int, dict[str, Any]]:
@@ -34,12 +42,13 @@ def _fake_trial(task: tuple[int, int, int | None]) -> tuple[int, int, dict[str, 
         },
         "random": {"apsp": value + 15, "flow": value + 16},
         "timings": {
-            "raw_sa": 0.0,
-            "global_solve": 0.0,
-            "global_embed": 0.0,
-            "clustered_solve": 0.0,
-            "clustered_embed": 0.0,
-            "random": 0.0,
+            "graph": value + 20,
+            "raw_sa": value + 21,
+            "global_solve": value + 22,
+            "global_embed": value + 23,
+            "clustered_solve": value + 24,
+            "clustered_embed": value + 25,
+            "random": value + 26,
         },
     }
 
@@ -48,7 +57,7 @@ def test_poster_trial_cache_key_is_stable() -> None:
     key = pr._poster_trial_cache_key(n=20, trial=3, seed=42)
     assert key == (
         'poster-results-trial:{"n": 20, "seed": 42, '
-        '"trial": 3, "version": 2}'
+        '"trial": 3, "version": 5}'
     )
 
 
@@ -96,6 +105,135 @@ def test_run_can_disable_poster_trial_cache(tmp_path, monkeypatch) -> None:
     )
 
     assert not (tmp_path / "poster_trial_cache").exists()
+
+
+def test_run_reuses_existing_aggregate_results_for_all_solvers(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(pr, "_plot_results", lambda results, output_dir: None)
+
+    existing = {
+        "sizes": [8],
+        "mr2s": {
+            "apsp": [80.0],
+            "flow": [81.0],
+            "qubo_vars": [82.0],
+            "subgraph_size": [83.0],
+            "phys_total": [84.0],
+            "phys_max": [85.0],
+            "phys_mean": [86.0],
+            "phys_min": [87.0],
+            "partition": [[{"selected_reason": "existing"}]],
+        },
+        "global": {
+            "apsp": [70.0],
+            "flow": [71.0],
+            "qubo_vars": [72.0],
+            "subgraph_size": [73.0],
+            "phys_total": [74.0],
+            "phys_max": [],
+            "phys_mean": [],
+            "phys_min": [],
+        },
+        "raw_sa": {"apsp": [60.0], "flow": [61.0]},
+        "random": {"apsp": [50.0], "flow": [51.0]},
+    }
+    results_path = tmp_path / "poster_results.json"
+    results_path.write_text(json.dumps(existing))
+
+    call_count = 0
+
+    def counted_trial(task):
+        nonlocal call_count
+        call_count += 1
+        return _fake_trial(task)
+
+    monkeypatch.setattr(pr, "_run_trial", counted_trial)
+
+    pr.run(
+        sizes=[8, 9],
+        num_graphs=1,
+        seed=0,
+        output_dir=str(tmp_path),
+        num_workers=0,
+    )
+
+    merged = json.loads(results_path.read_text())
+    assert call_count == 1
+    assert merged["sizes"] == [8, 9]
+    assert merged["raw_sa"]["apsp"][0] == 60.0
+    assert merged["global"]["apsp"][0] == 70.0
+    assert merged["mr2s"]["apsp"][0] == 80.0
+    assert merged["random"]["apsp"][0] == 50.0
+    assert merged["raw_sa"]["apsp"][1] == 9.0
+    assert math.isnan(merged["timings"]["graph"][0])
+    assert merged["timings"]["graph"][1] == 29.0
+
+
+def test_runner_accepts_custom_aggregator_and_plotter(tmp_path) -> None:
+    class CustomAggregator(PosterResultsAggregator):
+        def __init__(self) -> None:
+            self.received_sizes = []
+            self.received_trial_count = 0
+
+        def aggregate_full(self, sizes, trial_results):
+            self.received_sizes = sizes
+            self.received_trial_count = sum(len(items) for items in trial_results.values())
+            return {
+                "sizes": sizes,
+                "custom": {"trial_count": self.received_trial_count},
+            }
+
+    plotted = {}
+
+    def fake_plotter(results, output_dir):
+        plotted["results"] = results
+        plotted["output_dir"] = output_dir
+
+    aggregator = CustomAggregator()
+    runner = PosterResultsRunner(
+        config=PosterRunConfig(
+            sizes=[8],
+            num_graphs=1,
+            seed=0,
+            output_dir=str(tmp_path),
+            num_workers=0,
+            use_cache=False,
+        ),
+        worker=lambda task: _fake_trial((task[0], task[1], task[2])),
+        progress_printer=lambda *_args: None,
+        plotter=fake_plotter,
+        aggregator=aggregator,
+    )
+
+    results = runner.run()
+
+    assert aggregator.received_sizes == [8]
+    assert aggregator.received_trial_count == 1
+    assert results["custom"]["trial_count"] == 1
+    assert plotted["results"] == results
+    assert plotted["output_dir"] == str(tmp_path)
+
+
+def test_run_mr2s_trial_records_graph_generation_time(monkeypatch) -> None:
+    monkeypatch.setattr(pr._solver_helpers, "_run_clustered_solver", lambda _graph, _n: (
+        Mr2sSolverResult(
+            apsp=1.0,
+            flow=2.0,
+            qvars=3.0,
+            subgraph_size=4.0,
+            phys_total=5.0,
+            phys_max=6.0,
+            phys_mean=7.0,
+            phys_min=8.0,
+        ),
+        TrialTimings({"clustered_solve": 0.0, "clustered_embed": 0.0}),
+    ))
+
+    n, trial, result = pr._run_mr2s_trial((3, 0, 1))
+
+    assert n == 3
+    assert trial == 0
+    assert "graph" in result.timings.values
+    assert result.timings.values["graph"] >= 0.0
 
 
 def test_run_mr2s_only_merges_with_existing_results(tmp_path, monkeypatch) -> None:
@@ -151,12 +289,127 @@ def test_run_mr2s_only_merges_with_existing_results(tmp_path, monkeypatch) -> No
     assert merged["mr2s"]["partition"] == [[{"selected_reason": "test"}]]
 
 
+def test_run_mr2s_only_preserves_unrequested_existing_sizes(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(pr, "_plot_results", lambda results, output_dir: None)
+
+    existing = {
+        "sizes": [8, 9],
+        "mr2s": {
+            "apsp": [18.0, 19.0],
+            "flow": [28.0, 29.0],
+            "qubo_vars": [38.0, 39.0],
+            "subgraph_size": [48.0, 49.0],
+            "phys_total": [58.0, 59.0],
+            "phys_max": [68.0, 69.0],
+            "phys_mean": [78.0, 79.0],
+            "phys_min": [88.0, 89.0],
+            "partition": [[{"old": 8}], [{"old": 9}]],
+        },
+        "global": {"apsp": [1.0, 2.0], "flow": [3.0, 4.0]},
+        "raw_sa": {"apsp": [5.0, 6.0], "flow": [7.0, 8.0]},
+        "random": {"apsp": [9.0, 10.0], "flow": [11.0, 12.0]},
+        "timings": {
+            "graph": [1.0, 2.0],
+            "raw_sa": [3.0, 4.0],
+            "global_solve": [5.0, 6.0],
+            "global_embed": [7.0, 8.0],
+            "clustered_solve": [9.0, 10.0],
+            "clustered_embed": [11.0, 12.0],
+            "random": [13.0, 14.0],
+        },
+    }
+    results_path = tmp_path / "poster_results.json"
+    results_path.write_text(json.dumps(existing))
+
+    def fake_mr2s_trial(task):
+        return 8, 0, {
+            "mr2s": {
+                "apsp": 800.0,
+                "flow": 801.0,
+                "qvars": 802.0,
+                "sg": 803.0,
+                "phys_total": 804.0,
+                "phys_max": 805.0,
+                "phys_mean": 806.0,
+                "phys_min": 807.0,
+                "partition": {"selected_reason": "updated"},
+            },
+            "timings": {
+                "graph": 100.0,
+                "clustered_solve": 101.0,
+                "clustered_embed": 102.0,
+            },
+        }
+
+    monkeypatch.setattr(pr, "_run_mr2s_trial", fake_mr2s_trial)
+
+    pr.run_mr2s_only(
+        sizes=[8],
+        num_graphs=1,
+        seed=0,
+        output_dir=str(tmp_path),
+        num_workers=0,
+        use_cache=False,
+    )
+
+    merged = json.loads(results_path.read_text())
+    assert merged["sizes"] == [8, 9]
+    assert merged["global"] == existing["global"]
+    assert merged["raw_sa"] == existing["raw_sa"]
+    assert merged["random"] == existing["random"]
+    assert merged["mr2s"]["apsp"] == [800.0, 19.0]
+    assert merged["mr2s"]["partition"] == [[{"selected_reason": "updated"}], [{"old": 9}]]
+    assert merged["timings"]["graph"] == [100.0, 2.0]
+    assert merged["timings"]["clustered_solve"] == [101.0, 10.0]
+    assert merged["timings"]["raw_sa"] == [3.0, 4.0]
+
+
 def test_normalize_random_baseline_converts_legacy_zero_to_nan() -> None:
     normalized = pr._normalize_random_baseline({"apsp": 0.0, "flow": 0.0})
 
     assert math.isnan(normalized["apsp"])
     assert math.isnan(normalized["flow"])
     assert normalized["sample_count"] == 0
+
+
+def test_random_baseline_scores_flow_for_non_strong_orientation(monkeypatch) -> None:
+    graph = nx.path_graph(3)
+    orientation = nx.DiGraph([(0, 1), (1, 2)])
+    orientation.add_nodes_from(graph.nodes())
+
+    monkeypatch.setattr(
+        pr,
+        "_sample_random_orientations",
+        lambda _graph, max_samples, seed: [orientation],
+    )
+
+    result = pr._calculate_random_baseline(graph, n=3, seed=0, max_samples=1)
+
+    assert math.isnan(result["apsp"])
+    assert result["flow"] == 2.0
+    assert result["sample_count"] == 1
+    assert result["strong_sample_count"] == 0
+
+
+def test_random_baseline_averages_flow_across_all_orientations(monkeypatch) -> None:
+    graph = nx.cycle_graph(3)
+    strong_orientation = nx.DiGraph([(0, 1), (1, 2), (2, 0)])
+    non_strong_orientation = nx.DiGraph([(0, 1), (1, 2), (0, 2)])
+    for orientation in (strong_orientation, non_strong_orientation):
+        orientation.add_nodes_from(graph.nodes())
+
+    monkeypatch.setattr(
+        pr,
+        "_sample_random_orientations",
+        lambda _graph, max_samples, seed: [strong_orientation, non_strong_orientation],
+    )
+
+    result = pr._calculate_random_baseline(graph, n=3, seed=0, max_samples=2)
+
+    assert result["apsp"] == 1.5
+    assert result["flow"] == 4.0
+    assert result["sample_count"] == 2
+    assert result["strong_sample_count"] == 1
 
 
 def test_divide_graph_with_diagnostics_records_selected_partition(monkeypatch) -> None:

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -6,7 +6,11 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import pytest
 
-from src.visualizer import plot_score_correlations, plot_nhop_connectivity_comparison
+from src.visualizer import (
+    plot_nhop_connectivity_comparison,
+    plot_score_correlations,
+    plot_spent_time,
+)
 
 
 class TestPlotScoreCorrelations:
@@ -118,4 +122,37 @@ class TestPlotNhopConnectivityComparison:
             save_path=None,
         )
         assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+class TestPlotSpentTime:
+    def test_returns_figure(self):
+        fig = plot_spent_time(
+            sizes=[5, 10],
+            graph_time=[0.1, 0.2],
+            raw_sa_time=[1.0, 2.0],
+            global_solve_time=[1.5, 2.5],
+            global_embed_time=[0.3, 0.4],
+            clustered_solve_time=[1.2, 2.2],
+            clustered_embed_time=[0.0, 0.1],
+            random_time=[0.01, 0.02],
+            save_path=None,
+        )
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_saves_png(self, tmp_path):
+        out = tmp_path / "spent_time.png"
+        fig = plot_spent_time(
+            sizes=[5],
+            graph_time=[0.1],
+            raw_sa_time=[1.0],
+            global_solve_time=[1.5],
+            global_embed_time=[0.3],
+            clustered_solve_time=[1.2],
+            clustered_embed_time=[0.0],
+            random_time=[0.01],
+            save_path=str(out),
+        )
+        assert out.exists()
         plt.close(fig)


### PR DESCRIPTION
## 변경 사항
- poster-results 코드를 runner, model, solver, plotting, cache 모듈로 분리했습니다.
- mr2s-module을 0.0.8로 올리고 Robbin + MR2S, IteratedLocalSearch + MR2S solver 변형을 추가했습니다.
- DnC MR2S를 partition strategy별로 분리하고 기존 solver plot 안에 함께 표시합니다.
- spent_time plot에서 embed/probe time은 제외하고 solve time만 표시합니다.
- README에 poster-results 사용법과 결과 설명을 추가했습니다.

## 검증
- .venv/bin/python -m pytest tests/test_poster_results_cmd.py tests/test_visualizer.py -v
- .venv/bin/python main.py poster-results --sizes 5 10 20 --num-graphs 1 --num-workers 0 --output-dir results/poster_smoke_0_0_8 --no-cache

Closes #24