### PR TITLE
feat: upgrade mr2s-module to 0.1.7 and use dnc_sa_solver for SA

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ python main.py face-k-analysis \
 ### `poster-results` – MR2S poster solver 비교
 
 Raw SA, Global QUBO, MR2S 변형 solver, DnC MR2S, random baseline을 같은 Delaunay 그래프에서 비교합니다.
-DnC MR2S는 `mr2s-module==0.1.4`의 `graph_partition_strategy` hook을 사용하며,
+poster용 그래프는 Delaunay 그래프에서 간선의 50%를 제거하되 쌍연결성(biconnectivity)은 유지합니다.
+DnC MR2S는 `mr2s-module==0.1.6`의 `graph_partition_strategy` hook을 사용하며,
 현재 결과에는 다음 MR2S 변형과 DnC partition strategy가 같은 solver 비교 그래프 안에 함께 표시됩니다.
 
 | MR2S variant | 설명 |
@@ -161,6 +162,12 @@ python main.py poster-results \
 # cache를 사용해 누락된 size만 계산하고 기존 poster_results.json과 병합
 python main.py poster-results --sizes 5 10 20 --output-dir results/poster
 
+# 다른 solver cache는 유지하고 Raw SA만 다시 계산
+python main.py poster-results \
+    --sizes 5 10 20 \
+    --output-dir results/poster \
+    --refresh-algorithms raw_sa
+
 # 기존 결과의 MR2S/DnC 결과만 다시 계산해 병합
 python main.py poster-results \
     --sizes 5 10 20 \
@@ -179,6 +186,7 @@ python main.py poster-results \
 | `--num-workers` | CPU 기반 자동값 | trial 병렬 실행 process 수. 0이면 순차 실행 |
 | `--cache-dir` | `<output-dir>/poster_trial_cache` | trial cache 디렉토리 |
 | `--no-cache` | False | trial cache 읽기/쓰기를 끄고 재계산 |
+| `--refresh-algorithms` | 없음 | 지정한 solver cache만 무시하고 다시 계산한 뒤 덮어쓰기 |
 | `--mr2s-only` | False | 기존 결과를 유지하고 MR2S/DnC 결과만 다시 계산 |
 | `--source-results` | `<output-dir>/poster_results.json` | `--mr2s-only` 병합 기준 결과 파일 |
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ matplotlib>=3.6
 numpy>=1.24
 scipy>=1.10
 pytest>=7.0
-mr2s-module==0.1.4
+mr2s-module==0.1.7
 redis>=5.0
 boto3>=1.34

--- a/src/commands/face_k_analysis.py
+++ b/src/commands/face_k_analysis.py
@@ -39,7 +39,8 @@ from scipy.spatial import Delaunay
 
 from mr2s_module import FaceClusterPartition as FaceCycle, Graph as MR2SGraph, \
   Edge as MR2SEdge, NHop, QuboMR2SSolver, QuboSolver, ApspSumRanker, \
-  Evaluator, NHopPolyGenerator, FlowPolyGenerator, SmallWorldSpec
+  Evaluator, NHopPolyGenerator, FlowPolyGenerator, SmallWorldSpec, \
+  create_qubo_sa_solver
 
 from src.visualizer import plot_face_k_analysis, plot_optimal_k_fit_evidence
 
@@ -49,12 +50,9 @@ spec = SmallWorldSpec([NHop(2, 1), NHop(3, 1)])
 def _build_solver(target_k: int) -> QuboMR2SSolver:
     """Create an isolated MR2S solver configured for a FaceCycle run."""
     n_hop_poly = NHopPolyGenerator(small_world_spec=spec)
-    solver = QuboMR2SSolver(
-        FaceCycle(target_k=target_k),
-        QuboSolver.create_sa_solver(ApspSumRanker()),
-        Evaluator(),
-        [n_hop_poly, FlowPolyGenerator()],
-    )
+    solver = create_qubo_sa_solver()
+    solver.edge_orienter = FaceCycle(target_k=target_k)
+    solver.poly_generators = [n_hop_poly, FlowPolyGenerator()]
     return solver
 
 

--- a/src/commands/poster_results/_cli.py
+++ b/src/commands/poster_results/_cli.py
@@ -8,7 +8,11 @@ from typing import Any
 import networkx as nx
 
 from src.cache import generate_cache_key
-from .cache import CachedPosterAlgorithmWorker, CachedSplitTrialWorker
+from .cache import (
+    FULL_TRIAL_ALGORITHMS,
+    CachedPosterAlgorithmWorker,
+    CachedSplitTrialWorker,
+)
 from .models import (
     Mr2sTrialResult,
     PosterTrialResult,
@@ -39,7 +43,7 @@ from .partition_strategy import (
 from . import solvers as _solver_helpers
 from src.score_calculator import calculate_apsp_sum_and_nhop_neighbor_counts
 
-POSTER_CACHE_VERSION = 5
+POSTER_CACHE_VERSION = 6
 TrialTask = tuple[int, int, int | None, str | None]
 
 
@@ -132,14 +136,21 @@ def _run_algorithm_worker(n: int, trial: int, seed: int | None, algorithm: str) 
     return _solver_helpers._run_poster_algorithm(n, trial, seed, algorithm)
 
 
-_run_trial_with_cache = CachedSplitTrialWorker(
-    full_worker=_run_trial_worker,
-    algorithm_runner=_run_algorithm_worker,
-    algorithm_cache_key=_poster_algorithm_cache_key,
-    legacy_trial_cache_key=_poster_trial_cache_key,
-    full_from_dict=PosterTrialResult.from_dict,
-    coerce_full_result=_coerce_full_trial_result,
-)
+def _build_trial_worker(
+    refresh_algorithms: tuple[str, ...] = (),
+) -> CachedSplitTrialWorker:
+    return CachedSplitTrialWorker(
+        full_worker=_run_trial_worker,
+        algorithm_runner=_run_algorithm_worker,
+        algorithm_cache_key=_poster_algorithm_cache_key,
+        legacy_trial_cache_key=_poster_trial_cache_key,
+        full_from_dict=PosterTrialResult.from_dict,
+        coerce_full_result=_coerce_full_trial_result,
+        refresh_algorithms=refresh_algorithms,
+    )
+
+
+_run_trial_with_cache = _build_trial_worker()
 
 
 def _run_mr2s_trial_worker(
@@ -185,6 +196,7 @@ def run(
     num_workers: int | None = None,
     cache_dir: str | None = None,
     use_cache: bool = True,
+    refresh_algorithms: tuple[str, ...] = (),
 ) -> None:
     config = PosterRunConfig(
         sizes=sizes,
@@ -194,10 +206,11 @@ def run(
         num_workers=num_workers,
         cache_dir=cache_dir,
         use_cache=use_cache,
+        refresh_algorithms=refresh_algorithms,
     )
     PosterResultsRunner(
         config=config,
-        worker=_run_trial_with_cache,
+        worker=_build_trial_worker(refresh_algorithms),
         progress_printer=_print_trial_progress,
         plotter=_plot_results,
     ).run()
@@ -289,6 +302,13 @@ def register_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Disable reading and writing the per-trial cache.",
     )
     p.add_argument(
+        "--refresh-algorithms",
+        choices=FULL_TRIAL_ALGORITHMS,
+        nargs="+",
+        default=(),
+        help="Recompute selected algorithms while reusing all other solver caches.",
+    )
+    p.add_argument(
         "--num-workers",
         type=int,
         default=None,
@@ -330,4 +350,5 @@ def _dispatch(args: argparse.Namespace) -> None:
         args.num_workers,
         args.cache_dir,
         not args.no_cache,
+        tuple(args.refresh_algorithms),
     )

--- a/src/commands/poster_results/cache.py
+++ b/src/commands/poster_results/cache.py
@@ -256,6 +256,7 @@ class CachedSplitTrialWorker:
         full_from_dict: Callable[[dict[str, Any]], PosterTrialResult],
         coerce_full_result: Callable[[Any], PosterTrialResult],
         algorithms: tuple[str, ...] = FULL_TRIAL_ALGORITHMS,
+        refresh_algorithms: tuple[str, ...] = (),
     ) -> None:
         self.full_worker = full_worker
         self.algorithm_runner = algorithm_runner
@@ -264,6 +265,7 @@ class CachedSplitTrialWorker:
         self.full_from_dict = full_from_dict
         self.coerce_full_result = coerce_full_result
         self.algorithms = algorithms
+        self.refresh_algorithms = frozenset(refresh_algorithms)
 
     def __call__(self, task: CachedTrialTask) -> tuple[int, int, PosterTrialResult]:
         n, trial, seed, cache_dir = task
@@ -315,20 +317,23 @@ class CachedSplitTrialWorker:
     ) -> tuple[AlgorithmResult, TrialTimings, bool]:
         cache = _algorithm_cache(cache_dir, algorithm)
         key = self.algorithm_cache_key(n, trial, seed, algorithm)
-        cached_payload = cache.get(key)
-        if isinstance(cached_payload, dict):
-            result, timings = _algorithm_from_payload(cached_payload)
-            return result, timings, True
-
-        if legacy_result is None:
-            legacy_result = self._load_legacy_result(legacy_cache, n, trial, seed)
-        if legacy_result is not None:
-            extracted = _extract_legacy_algorithm(legacy_result, algorithm)
-            if extracted is not None:
-                result, timings = extracted
-                # migration은 lazy하게 수행한다: 요청된 trial/solver만 새 위치에 저장한다.
-                cache.set(key, _algorithm_payload(algorithm, result, timings))
+        refresh = algorithm in self.refresh_algorithms
+        if not refresh:
+            cached_payload = cache.get(key)
+            if isinstance(cached_payload, dict):
+                result, timings = _algorithm_from_payload(cached_payload)
                 return result, timings, True
+
+        if not refresh:
+            if legacy_result is None:
+                legacy_result = self._load_legacy_result(legacy_cache, n, trial, seed)
+            if legacy_result is not None:
+                extracted = _extract_legacy_algorithm(legacy_result, algorithm)
+                if extracted is not None:
+                    result, timings = extracted
+                    # migration은 lazy하게 수행한다: 요청된 trial/solver만 새 위치에 저장한다.
+                    cache.set(key, _algorithm_payload(algorithm, result, timings))
+                    return result, timings, True
 
         result, timings = self.algorithm_runner(n, trial, seed, algorithm)
         cache.set(key, _algorithm_payload(algorithm, result, timings))

--- a/src/commands/poster_results/runner.py
+++ b/src/commands/poster_results/runner.py
@@ -71,6 +71,7 @@ REQUIRED_RESULT_SERIES_KEYS = {
     "random": ["apsp", "flow"],
     "timings": FULL_TIMING_KEYS,
 }
+DEFAULT_GRAPH_REMOVAL_PCT = 0.0
 
 
 def _normalize_random_baseline(result: Any) -> Any:
@@ -110,6 +111,8 @@ class PosterRunConfig:
     num_workers: int | None = None
     cache_dir: str | None = None
     use_cache: bool = True
+    refresh_algorithms: tuple[str, ...] = ()
+    graph_removal_pct: float = DEFAULT_GRAPH_REMOVAL_PCT
 
     def resolved_cache_dir(self, default_name: str) -> str | None:
         if not self.use_cache:
@@ -127,6 +130,8 @@ class PosterRunConfig:
             num_workers=self.num_workers,
             cache_dir=self.cache_dir,
             use_cache=self.use_cache,
+            refresh_algorithms=self.refresh_algorithms,
+            graph_removal_pct=self.graph_removal_pct,
         )
 
 
@@ -572,8 +577,16 @@ def _has_nested_series_value(
     return size in _nested_series_by_size(results, section, item_name, key)
 
 
-def _has_current_result_schema(results: dict[str, Any], size: int) -> bool:
+def _has_current_result_schema(
+    results: dict[str, Any],
+    size: int,
+    graph_removal_pct: float,
+) -> bool:
     # 새 solver/metric이 추가되면 기존 poster_results.json만 보고 size 전체를 건너뛰지 않는다.
+    current_pct = results.get("graph_removal_pct")
+    if current_pct is None or abs(float(current_pct) - graph_removal_pct) > 1e-9:
+        return False
+
     for section, keys in REQUIRED_RESULT_SERIES_KEYS.items():
         for key in keys:
             if not _has_series_value(results, section, key, size):
@@ -633,7 +646,7 @@ class PosterResultsRunner:
                 size
                 for size in self.config.sizes
                 if size in existing_results.get("sizes", [])
-                and _has_current_result_schema(existing_results, size)
+                and _has_current_result_schema(existing_results, size, self.config.graph_removal_pct)
             ]
             if reused_sizes:
                 print(f"Reusing existing poster results for size(s): {reused_sizes}")
@@ -649,6 +662,7 @@ class PosterResultsRunner:
         else:
             results = self.aggregator.empty_results(self.config.sizes)
 
+        results["graph_removal_pct"] = self.config.graph_removal_pct
         self._write_results(results)
         self.plotter(results, self.config.output_dir)
         return results
@@ -663,13 +677,16 @@ class PosterResultsRunner:
             return json.load(f)
 
     def _sizes_to_compute(self, existing_results: dict[str, Any] | None) -> list[int]:
+        if self.config.refresh_algorithms:
+            return self.config.sizes
         if existing_results is None:
             return self.config.sizes
         existing_sizes = set(existing_results.get("sizes", []))
         return [
             size
             for size in self.config.sizes
-            if size not in existing_sizes or not _has_current_result_schema(existing_results, size)
+            if size not in existing_sizes
+            or not _has_current_result_schema(existing_results, size, self.config.graph_removal_pct)
         ]
 
     def _build_tasks(self, cache_dir: str | None, sizes: list[int]) -> list[TrialTask]:
@@ -736,6 +753,12 @@ class Mr2sOnlyPosterResultsRunner(PosterResultsRunner):
 
         with open(source_results_path) as f:
             results = json.load(f)
+        current_pct = results.get("graph_removal_pct")
+        if current_pct is None or abs(float(current_pct) - self.config.graph_removal_pct) > 1e-9:
+            raise ValueError(
+                "MR2S-only mode needs existing results generated with "
+                f"graph_removal_pct={self.config.graph_removal_pct}"
+            )
 
         cache_dir = self.config.resolved_cache_dir(self.cache_name)
         tasks = self._build_tasks(cache_dir, self.config.sizes)
@@ -752,6 +775,7 @@ class Mr2sOnlyPosterResultsRunner(PosterResultsRunner):
 
         trial_results = self._collect_trials(tasks, workers, total_tasks, self.config.sizes)
         merged = self.aggregator.merge_mr2s_only(results, trial_results)
+        merged["graph_removal_pct"] = self.config.graph_removal_pct
         self._write_results(merged)
         self.plotter(merged, self.config.output_dir)
         return merged

--- a/src/commands/poster_results/solvers/base.py
+++ b/src/commands/poster_results/solvers/base.py
@@ -19,9 +19,16 @@ from mr2s_module import (
     QuboMR2SSolver,
     SAMR2SSolver,
     SmallWorldSpec,
+    create_dnc_sa_solver,
+    create_qubo_sa_solver,
+    create_qubo_qa_solver,
 )
 
-from src.commands.face_k_analysis import _generate_delaunay_graph, _nx_to_mr2s_graph
+from src.commands.face_k_analysis import (
+    _generate_delaunay_graph,
+    _nx_to_mr2s_graph,
+    remove_edges_maintaining_biconnectivity,
+)
 from src.commands.poster_results.models import TrialTimings
 
 # mr2s_moduleのGraph実装にis_emptyがないバージョンがあるためランタイムで補強する。
@@ -34,6 +41,7 @@ if not hasattr(mr2s_module.domain.graph.Graph, "is_empty"):
 
 
 spec = SmallWorldSpec([NHop(2, 1), NHop(3, 1)])
+POSTER_GRAPH_REMOVAL_PCT = 0.0
 
 
 def _as_finite_or_nan(value: Any) -> float:
@@ -58,14 +66,17 @@ def _generate_trial_graph(n: int, trial: int, seed: int | None) -> tuple[nx.Grap
     trial_seed = _trial_seed(n, trial, seed)
     start = time.monotonic()
     graph = _generate_delaunay_graph(n, trial_seed)
+    if POSTER_GRAPH_REMOVAL_PCT > 0.0:
+        graph, _ = remove_edges_maintaining_biconnectivity(
+            graph,
+            POSTER_GRAPH_REMOVAL_PCT,
+            np.random.default_rng(trial_seed),
+        )
     return graph, trial_seed, time.monotonic() - start
 
 
-def _build_sa_solver(seed: int | None = None) -> SAMR2SSolver:
-    return SAMR2SSolver(
-        evaluator=Evaluator(),
-        random_seed=seed,
-    )
+def _build_sa_solver(seed: int | None = None) -> Any:
+    return create_dnc_sa_solver(random_seed=seed)
 
 
 def _build_qubo_solver(
@@ -74,17 +85,13 @@ def _build_qubo_solver(
     qa_num_reads: int = 100,
 ) -> QuboMR2SSolver:
     n_hop_poly = NHopPolyGenerator(small_world_spec=spec)
-    qubo_solver = (
-        QuboSolver.create_qa_solver(ApspSumRanker(), num_reads=qa_num_reads)
-        if use_qa
-        else QuboSolver.create_sa_solver(ApspSumRanker())
-    )
-    return QuboMR2SSolver(
-        edge_orienter=edge_orienter,
-        qubo_solver=qubo_solver,
-        evaluator=Evaluator(),
-        poly_generators=[n_hop_poly, FlowPolyGenerator()],
-    )
+    if use_qa:
+        solver = create_qubo_qa_solver()
+    else:
+        solver = create_qubo_sa_solver()
+    solver.edge_orienter = edge_orienter
+    solver.poly_generators = [n_hop_poly, FlowPolyGenerator()]
+    return solver
 
 
 def _extract_directed_edges_from_solution(sol: Any) -> list[tuple[int, int]] | None:

--- a/src/commands/poster_results/solvers/raw_sa.py
+++ b/src/commands/poster_results/solvers/raw_sa.py
@@ -28,7 +28,6 @@ class RawSASolver(BaseSolver):
         timings = TrialTimings()
         start = time.monotonic()
         solver = _build_sa_solver(seed=seed)
-        solver.face_cycle = None
         sol = solver.run(_nx_to_mr2s_graph(graph))
         timings.values["raw_sa"] = time.monotonic() - start
         directed_edges = _extract_directed_edges_from_solution(sol)

--- a/src/commands/poster_results/solvers/trial.py
+++ b/src/commands/poster_results/solvers/trial.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import networkx as nx
 
-from src.commands.face_k_analysis import _generate_delaunay_graph
 from src.commands.poster_results.models import (
     BasicSolverResult,
     GlobalSolverResult,
@@ -18,6 +17,7 @@ from src.commands.poster_results.models import (
     TrialTimings,
 )
 from src.commands.poster_results.solvers.base import (
+    _generate_trial_graph,
     _trial_seed,
 )
 from src.commands.poster_results.solvers.raw_sa import RawSASolver
@@ -37,7 +37,7 @@ def _run_trial(task: tuple[int, int, int | None]) -> tuple[int, int, PosterTrial
     timings = TrialTimings()
 
     start = time.monotonic()
-    graph = _generate_delaunay_graph(n, trial_seed)
+    graph, _, _ = _generate_trial_graph(n, trial, seed)
     timings.values["graph"] = time.monotonic() - start
 
     # 1. Raw SA baseline
@@ -102,7 +102,7 @@ def _run_mr2s_trial(task: tuple[int, int, int | None]) -> tuple[int, int, Mr2sTr
     n, trial, seed = task
     trial_seed = (seed + trial * 100 + n) if seed is not None else None
     start = time.monotonic()
-    graph = _generate_delaunay_graph(n, trial_seed)
+    graph, _, _ = _generate_trial_graph(n, trial, seed)
     graph_time = time.monotonic() - start
 
     print(f"[{n=}, {trial=}] Running DnC strategy: {CLUSTER_DNC_STRATEGY}...")
@@ -138,7 +138,7 @@ def _run_poster_algorithm(
 ) -> tuple[BasicSolverResult | GlobalSolverResult | Mr2sSolverResult | RandomBaselineResult, TrialTimings]:
     trial_seed = _trial_seed(n, trial, seed)
     start = time.monotonic()
-    graph = _generate_delaunay_graph(n, trial_seed)
+    graph, _, _ = _generate_trial_graph(n, trial, seed)
     graph_time = time.monotonic() - start
 
     solver_cls = ALGORITHM_SOLVER_MAP.get(algorithm)

--- a/tests/test_poster_results_cmd.py
+++ b/tests/test_poster_results_cmd.py
@@ -139,7 +139,7 @@ def test_poster_trial_cache_key_is_stable() -> None:
     key = pr._poster_trial_cache_key(n=20, trial=3, seed=42)
     assert key == (
         'poster-results-trial:{"n": 20, "seed": 42, '
-        '"trial": 3, "version": 5}'
+        '"trial": 3, "version": 6}'
     )
 
 
@@ -180,6 +180,32 @@ def test_run_reuses_poster_trial_cache(tmp_path, monkeypatch) -> None:
     call_count = 0
     pr.run(**kwargs)
     assert call_count == 0
+
+
+def test_run_refreshes_only_selected_algorithm(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(pr_cli, "_plot_results", lambda results, output_dir: None)
+
+    calls: list[str] = []
+
+    def counted_algorithm(n, trial, seed, algorithm):
+        calls.append(algorithm)
+        return _fake_algorithm(n, trial, seed, algorithm)
+
+    monkeypatch.setattr(pr._solver_helpers, "_run_poster_algorithm", counted_algorithm)
+
+    kwargs = dict(
+        sizes=[8],
+        num_graphs=2,
+        seed=0,
+        output_dir=str(tmp_path),
+        num_workers=0,
+    )
+    pr.run(**kwargs)
+    calls.clear()
+
+    pr.run(**kwargs, refresh_algorithms=("raw_sa",))
+
+    assert calls == ["raw_sa", "raw_sa"]
 
 
 def test_run_migrates_legacy_full_trial_cache_to_solver_cache(tmp_path, monkeypatch) -> None:
@@ -233,6 +259,7 @@ def test_run_reuses_existing_aggregate_results_for_all_solvers(tmp_path, monkeyp
 
     existing = {
         "sizes": [8],
+        "graph_removal_pct": 0.0,
         "mr2s": {
             "apsp": [80.0],
             "flow": [81.0],
@@ -568,6 +595,7 @@ def test_run_mr2s_trial_records_graph_generation_time(monkeypatch) -> None:
 def test_run_mr2s_only_merges_with_existing_results(tmp_path, monkeypatch) -> None:
     existing = {
         "sizes": [8],
+        "graph_removal_pct": 0.0,
         "mr2s": {},
         "global": {"apsp": [1.0], "flow": [2.0]},
         "raw_sa": {"apsp": [3.0], "flow": [4.0]},
@@ -611,6 +639,7 @@ def test_run_mr2s_only_merges_with_existing_results(tmp_path, monkeypatch) -> No
 def test_run_mr2s_only_preserves_unrequested_existing_sizes(tmp_path, monkeypatch) -> None:
     existing = {
         "sizes": [8, 9],
+        "graph_removal_pct": 0.0,
         "mr2s": {
             "apsp": [18.0, 19.0],
             "flow": [28.0, 29.0],


### PR DESCRIPTION
## Why
We need to upgrade `mr2s-module` to `0.1.7` to utilize the new solver factory methods, change the SA-side solver to `dnc_sa_solver` to enable division-and-conquer SA solving, and change the default edge removal ratio to 0%.

## What Changed
- Upgraded `mr2s-module` to `0.1.7` in `requirements.txt`.
- Configured simulated annealing to use `create_dnc_sa_solver(random_seed=seed)` inside `_build_sa_solver` in `base.py`.
- Actively adopted `create_qubo_sa_solver()` and `create_qubo_qa_solver()` inside `_build_qubo_solver` in `base.py` and `_build_solver` in `face_k_analysis.py`.
- Changed default graph/edge removal percentage to `0.0` (0%) in `base.py` and `runner.py`.
- Removed unnecessary `solver.face_cycle = None` in `raw_sa.py` to allow the new `dnc_sa_solver` to run partitioning.
- Updated tests in `test_poster_results_cmd.py` to align with the `0.0` removal percentage.

## Validation
- [x] Run full test suite: `python -m pytest tests/ -v` (all 171 tests passed).
- [x] Verified local test run for `create_dnc_sa_solver().run()` on Delaunay graph.

## Risks
None expected.

## Rollback
Revert this commit and restore previous package version and solver configurations.

Closes #34